### PR TITLE
Bugfix/indicator comparison

### DIFF
--- a/ansys/grantami/bomanalytics/indicators.py
+++ b/ansys/grantami/bomanalytics/indicators.py
@@ -37,7 +37,7 @@ class _Flag(Enum):
         return obj
 
     def __le__(self, other):
-        """ Allows comparison both to another flag and to an indicator that has this flag set as its result.
+        """Allows comparison both to another flag and to an indicator that has this flag set as its result.
 
         Raises
         ------
@@ -46,7 +46,7 @@ class _Flag(Enum):
         TypeError
             If the other object isn't this flag's type or this flag's indicator's type.
         """
-        
+
         return self.__eq__(other) or self < other
 
 
@@ -94,7 +94,7 @@ class RoHSFlag(_Flag):
     )
 
     def __lt__(self, other):
-        """ Allows comparison both to another flag and to an indicator that has this flag set as its result.
+        """Allows comparison both to another flag and to an indicator that has this flag set as its result.
 
         Raises
         ------
@@ -115,7 +115,7 @@ class RoHSFlag(_Flag):
             raise TypeError(f"Cannot compare {type(self)} with {type(other)}")
 
     def __eq__(self, other):
-        """ Allows comparison both to another flag and to an indicator that has this flag set as its result.
+        """Allows comparison both to another flag and to an indicator that has this flag set as its result.
 
         Raises
         ------
@@ -176,7 +176,7 @@ class WatchListFlag(_Flag):
     WatchListUnknown = 7, """There is not enough information to determine compliance. *Compliance is unknown.*"""
 
     def __lt__(self, other):
-        """ Allows comparison both to another flag and to an indicator that has this flag set as its result.
+        """Allows comparison both to another flag and to an indicator that has this flag set as its result.
 
         Raises
         ------
@@ -197,7 +197,7 @@ class WatchListFlag(_Flag):
             raise TypeError(f"Cannot compare {type(self)} with {type(other)}")
 
     def __eq__(self, other):
-        """ Allows comparison both to another flag and to an indicator that has this flag set as its result.
+        """Allows comparison both to another flag and to an indicator that has this flag set as its result.
 
         Raises
         ------
@@ -279,7 +279,7 @@ class _Indicator(ABC):
             raise KeyError(f'Unknown flag "{flag}" for indicator "{repr(self)}"').with_traceback(e.__traceback__)
 
     def __eq__(self, other):
-        """ Allows comparison both to another indicator and to a flag of the correct type for the concrete class.
+        """Allows comparison both to another indicator and to a flag of the correct type for the concrete class.
 
         Raises
         ------
@@ -301,7 +301,7 @@ class _Indicator(ABC):
             raise ValueError(f"Indicator {str(other)} has no flag, so cannot be compared")
 
     def __lt__(self, other):
-        """ Allows comparison both to another indicator and to a flag of the correct type for the concrete class.
+        """Allows comparison both to another indicator and to a flag of the correct type for the concrete class.
 
         Raises
         ------
@@ -323,7 +323,7 @@ class _Indicator(ABC):
             raise ValueError(f"Indicator {str(other)} has no flag, so cannot be compared")
 
     def __le__(self, other):
-        """ Allows comparison both to another indicator and to a flag of the correct type for the concrete class.
+        """Allows comparison both to another indicator and to a flag of the correct type for the concrete class.
 
         Raises
         ------

--- a/tests/test_bom_indicators.py
+++ b/tests/test_bom_indicators.py
@@ -31,16 +31,20 @@ def get_low_flag(flag_enum):
 @pytest.mark.parametrize("indicator", [indicators.RoHSIndicator, indicators.WatchListIndicator])
 class TestFlagComparison:
     def test_flag_greater_than(self, indicator):
-        assert get_high_flag(indicator.available_flags) > get_random_flag(indicator.available_flags) \
-               > get_low_flag(indicator.available_flags)
+        high_flag = get_high_flag(indicator.available_flags)
+        middle_flag = get_random_flag(indicator.available_flags)
+        low_flag = get_low_flag(indicator.available_flags)
+        assert high_flag > middle_flag > low_flag
 
     def test_flag_greater_than_equal_to(self, indicator):
         flag = get_random_flag(indicator.available_flags)
         assert flag >= flag >= get_low_flag(indicator.available_flags)
 
     def test_flag_less_than(self, indicator):
-        assert get_low_flag(indicator.available_flags) < get_random_flag(indicator.available_flags) \
-               < get_high_flag(indicator.available_flags)
+        high_flag = get_high_flag(indicator.available_flags)
+        middle_flag = get_random_flag(indicator.available_flags)
+        low_flag = get_low_flag(indicator.available_flags)
+        assert low_flag < middle_flag < high_flag
 
     def test_flag_less_than_equal_to(self, indicator):
         flag = get_random_flag(indicator.available_flags)
@@ -103,8 +107,10 @@ class TestIndicators:
         test_indicator = create_indicator(indicator)
         test_indicator.flag = get_random_flag(test_indicator.available_flags).name
 
-        assert repr(test_indicator) == f"<{indicator.__name__}, name: {test_indicator.name}," \
-                                       f" flag: {str(test_indicator.flag)}>"
+        assert (
+            repr(test_indicator) == f"<{indicator.__name__}, name: {test_indicator.name},"
+            f" flag: {str(test_indicator.flag)}>"
+        )
 
     def test_indicator_repr_without_flag(self, indicator):
         test_indicator = create_indicator(indicator)
@@ -199,6 +205,7 @@ class TestIndicatorComparison:
         assert high_indicator >= test_indicator
         assert not same_indicator < test_indicator
         assert not high_indicator < test_indicator
+
 
 @pytest.mark.parametrize(
     "indicator, other_indicator",


### PR DESCRIPTION
Before this fix, comparisons could only be made from flag to flag or indicator to indicator (in the case of indicator to indicator, the .flag properties were compared for each). This is problematic, because in the case where you want to compare results with some 'threshold' value you are comparing an indicator to a flag. This isn't obvious, and is likely to cause confusion when using the API.

This fix enables 'mix-and-match' (heterogeneous) comparisons, allowing an indicator result object to be compared to a flag and vice-versa. Some details:

- Required moving the __lt__ and __eq__ methods for flags to the concrete implementations, so that the compatible indicator type can be specified. This ensures you can't compare a WatchListIndicator with a RoHSFlag, and vice versa.
- Explicitly test flag comparisons, instead of just indicator comparisons
- Test all heterogeneous comparisons in both directions. This results in some duplication (since the __gt__ method is not implemented, python just reverses the __lt__ method), but the tests are small and cheap to run.