### PR TITLE
Connection repr improvements

### DIFF
--- a/ansys/grantami/bomanalytics/_connection.py
+++ b/ansys/grantami/bomanalytics/_connection.py
@@ -104,7 +104,12 @@ class BomAnalyticsClient(common.ApiClient):
         }
 
     def __repr__(self):
-        return f"<BomServicesClient: url={self.api_url}>"
+        base_repr = f'<BomServicesClient: url="{self.api_url}", dbkey="{self._db_key}"'
+        custom_tables = ", ".join([f'{k}="{v}"' for k, v in self._table_names.items() if v])
+        if custom_tables:
+            return base_repr + f", {custom_tables}>"
+        else:
+            return base_repr + ">"
 
     def set_database_details(
         self,

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -32,3 +32,25 @@ def test_custom_dbkey(mock_connection):
 
 def test_default_dbkey(mock_connection):
     assert mock_connection._query_arguments["database_key"] == "MI_Restricted_Substances"
+
+
+def test_repr_default_dbkey(mock_connection):
+    assert repr(mock_connection) == '<BomServicesClient: url="http://localhost/mi_servicelayer", ' \
+                                    'dbkey="MI_Restricted_Substances">'
+
+
+def test_repr_custom_dbkey(mock_connection):
+    mock_connection.set_database_details(database_key="RS_DB")
+    assert repr(mock_connection) == '<BomServicesClient: url="http://localhost/mi_servicelayer", dbkey="RS_DB">'
+
+
+def test_repr_default_dbkey_custom_table(mock_connection):
+    mock_connection.set_database_details(specifications_table_name="My Specs")
+    assert repr(mock_connection) == '<BomServicesClient: url="http://localhost/mi_servicelayer", ' \
+                                    'dbkey="MI_Restricted_Substances", specifications_table_name="My Specs">'
+
+
+def test_repr_custom_dbkey_custom_table(mock_connection):
+    mock_connection.set_database_details(database_key="RS_DB", specifications_table_name="My Specs")
+    assert repr(mock_connection) == '<BomServicesClient: url="http://localhost/mi_servicelayer", ' \
+                                    'dbkey="RS_DB", specifications_table_name="My Specs">'


### PR DESCRIPTION
Improvements to the connection __repr__ to include the database key (defaults to MI_Restricted_Substances), and custom table names if they have been defined.

Currently the repr is the only way people can see what the database key or custom table names are without using private properties. It might be a good idea to expose the database key separately, but I think the table names will be so infrequently used that polluting the interface with 6 different properties doesn't make sense.