### PR TITLE
Remove obsolete TODOs.

### DIFF
--- a/src/ansys/grantami/bomanalytics/__init__.py
+++ b/src/ansys/grantami/bomanalytics/__init__.py
@@ -2,4 +2,3 @@ from ._connection import Connection
 from ._exceptions import GrantaMIException
 
 __version__ = "0.1.0dev"
-# TODO use STK to extend BoM services objects? e.g. adding all references to sparsely referenced object

--- a/src/ansys/grantami/bomanalytics/_item_results.py
+++ b/src/ansys/grantami/bomanalytics/_item_results.py
@@ -472,7 +472,7 @@ class ImpactedSubstancesResultMixin(mixin_base_class):
 
         results = []
         for legislation_result in self.substances_by_legislation.values():
-            results.extend(legislation_result)  # TODO: Merge these property, i.e. take max amount? range?
+            results.extend(legislation_result)
         return results
 
     def __repr__(self) -> str:

--- a/src/ansys/grantami/bomanalytics/_query_results.py
+++ b/src/ansys/grantami/bomanalytics/_query_results.py
@@ -184,7 +184,7 @@ class ImpactedSubstancesBaseClass(ResultBaseClass):
             ) in item_result.substances_by_legislation.items():
                 results[legislation_name].extend(
                     legislation_result
-                )  # TODO: Merge these property, i.e. take max amount? range?
+                )
         return dict(results)
 
     @property
@@ -208,7 +208,7 @@ class ImpactedSubstancesBaseClass(ResultBaseClass):
         results = []
         for item_result in self._results:
             for legislation_result in item_result.substances_by_legislation.values():
-                results.extend(legislation_result)  # TODO: Merge these property, i.e. take max amount? range?
+                results.extend(legislation_result)
         return results
 
 

--- a/src/ansys/grantami/bomanalytics/indicators.py
+++ b/src/ansys/grantami/bomanalytics/indicators.py
@@ -358,7 +358,7 @@ class _Indicator(ABC):
         return self == other or self < other
 
 
-class RoHSIndicator(_Indicator):  # TODO Think about the class hierarchy here, IndicatorDefinition vs Result
+class RoHSIndicator(_Indicator):
     """Indicator object that represents RoHS-type compliance of a BoM object against one or more
     legislations.
 

--- a/src/ansys/grantami/bomanalytics/queries.py
+++ b/src/ansys/grantami/bomanalytics/queries.py
@@ -478,7 +478,7 @@ class _RecordBasedQueryBuilder(_BaseQueryBuilder, ABC):
         <MaterialCompliance: 2 materials, batch size = 100, 0 indicators>
         """
 
-        record_guids: List[str] = [r["record_guid"] for r in stk_records]  # TODO Handle database key
+        record_guids: List[str] = [r["record_guid"] for r in stk_records]
         query_builder: Query_Builder = self.with_record_guids(record_guids)
         return query_builder
 


### PR DESCRIPTION
These TODOs are no longer relevant. In some situations we've documented and approved the functionality, in others we have outstanding Issues that cover these topics.