### PR TITLE
Set user agent string

### DIFF
--- a/src/ansys/grantami/bomanalytics/__init__.py
+++ b/src/ansys/grantami/bomanalytics/__init__.py
@@ -1,13 +1,11 @@
 from ._connection import Connection
 from ._exceptions import GrantaMIException
 
-_PACKAGE_NAME = "ansys-grantami-bomanalytics"
-
 try:
     from importlib import metadata as metadata
 
-    __version__ = metadata.version(_PACKAGE_NAME)
+    __version__ = metadata.version("ansys-grantami-bomanalytics")
 except ImportError:
     from importlib_metadata import metadata as metadata_backport  # type: ignore[import]
 
-    __version__ = metadata_backport(_PACKAGE_NAME)["version"]
+    __version__ = metadata_backport("ansys-grantami-bomanalytics")["version"]

--- a/src/ansys/grantami/bomanalytics/_connection.py
+++ b/src/ansys/grantami/bomanalytics/_connection.py
@@ -15,23 +15,12 @@ DEFAULT_DBKEY : str
 from typing import overload, TYPE_CHECKING, Union, Dict, Optional, Type, Any
 import logging
 
-from ansys.openapi import common  # type: ignore[import]
+from ansys.openapi.common import ApiClientFactory, ApiClient, generate_user_agent  # type: ignore[import]
 from ansys.grantami.bomanalytics_openapi import models  # type: ignore[import]
 
 DEFAULT_DBKEY = "MI_Restricted_Substances"
 SERVICE_PATH = "/BomAnalytics/v1.svc"
 OIDC_HEADER_APPLICATION_NAME = "MI Scripting Toolkit"
-
-
-def generate_user_agent() -> str:
-    import platform
-    from . import __version__, _PACKAGE_NAME
-
-    os_version = platform.platform()
-    python_implementation = platform.python_implementation()
-    python_version = platform.python_version()
-    package_version = __version__
-    return f"{_PACKAGE_NAME}/{package_version} {python_implementation}/{python_version} ({os_version})"
 
 
 if TYPE_CHECKING:
@@ -62,7 +51,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger("ansys.grantami.bomanalytics")
 
 
-class Connection(common.ApiClientFactory):
+class Connection(ApiClientFactory):
     """Connect to an instance of Granta MI.
 
     Notes
@@ -105,20 +94,21 @@ class Connection(common.ApiClientFactory):
         return client
 
 
-class BomAnalyticsClient(common.ApiClient):
+class BomAnalyticsClient(ApiClient):
     """The class used to communicate with Granta MI. It is instantiated by the
     :class:`~ansys.grantami.bomanalytics.Connection` class defined above, and should not be instantiated directly.
     """
 
     def __init__(self, servicelayer_url: str, **kwargs: Any) -> None:
+        from . import __version__
+
         self._sl_url = servicelayer_url.strip("/")
         sl_url_with_service = self._sl_url + SERVICE_PATH
         logger.debug("Creating BomAnalyticsClient")
         logger.debug(f"Base Service Layer URL: {self._sl_url}")
         logger.debug(f"Service URL: {sl_url_with_service}")
         super().__init__(api_url=sl_url_with_service, **kwargs)
-
-        self.user_agent = generate_user_agent()
+        self.user_agent = generate_user_agent("ansys-grantami-bomanalytics", __version__)
         self._db_key = DEFAULT_DBKEY
         self._table_names: Dict[str, Optional[str]] = {
             "material_universe_table_name": None,


### PR DESCRIPTION
Closes #62 

There are some reports of cloudflare gateways rejecting traffic with a urllib3 user agent. This PR sets the user agent string to something non-default, which will hopefully eliminate spurious integration test failures.