### PR TITLE
67 - Add release job

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -217,14 +217,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      # used for documentation deployment
-      - name: Get Bot Application Token
-        id: get_workflow_token
-        uses: peter-murray/workflow-application-token-action@v1
-        with:
-          application_id: ${{ secrets.BOT_APPLICATION_ID }}
-          application_private_key: ${{ secrets.BOT_APPLICATION_PRIVATE_KEY }}
-
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
@@ -310,6 +302,14 @@ jobs:
           python-version: '3.10'
 
       - uses: actions/checkout@v2
+      
+      # used for documentation deployment
+      - name: Get Bot Application Token
+        id: get_workflow_token
+        uses: peter-murray/workflow-application-token-action@v1
+        with:
+          application_id: ${{ secrets.BOT_APPLICATION_ID }}
+          application_private_key: ${{ secrets.BOT_APPLICATION_PRIVATE_KEY }}
 
       - uses: actions/download-artifact@v2
         with:


### PR DESCRIPTION
Relates to #67 

This PR adds a release job for documentation and the wheel.

Documentation is released to gh-pages branch in the pyansys/grantami-bomanalytics-docs repository
Wheel will be published eventually, currently disabled