### PR TITLE
Use label name instead of bot name so all dependency test runs skip integration tests

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -273,7 +273,7 @@ jobs:
 
       - name: Set BUILD_EXAMPLES environment variable
         if: ${{ !contains(github.event.pull_request.labels.*.name, 'dependencies') }}
-        run: 1 >> $BUILD_EXAMPLES
+        run: export BUILD_EXAMPLES=1
 
       - name: Build HTML Documentation
         run:


### PR DESCRIPTION
Use `github.event.label.name` instead of `github.actor`. 

The reasoning for this is as follows:
- A token is needed to get the packages for openapi-common and grantami-bomanalytics-openapi from other repositories (this won't be the case once these packages are released, but it is required for now)
- However, workflows triggered by dependabot cannot access secrets, so the tests will always fail.
- We currently can't re-trigger the tests manually, because they will go through the full integration test suite

This change should mean that all PRs flagged as dependencies will go through the reduced testing process.

I have flagged this PR as 'dependencies' manually as a test. if this succeeds, I'll remove the flag and test again.

