### PR TITLE
Change pyansys breadcrumb

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -125,7 +125,7 @@ html_theme = "pyansys_sphinx_theme"
 html_logo = pyansys_logo_black
 html_theme_options = {
     "github_url": "https://github.com/pyansys/granta-bomanalytics",
-    "additional_breadcrumbs": [("PyAnsys", "https://docs.pyansys.com/")],
+    "additional_breadcrumbs": [("PyAnsys Documentation", "https://docs.pyansys.com/")],
     "show_breadcrumbs": True,
 }
 


### PR DESCRIPTION
This PR changes the PyAnsys breadcrumb to 'PyAnsys Documentation' to be consistent with other packages and the Python documentation ecosystem in general, c.f. https://docs.python.org/3/