### PR TITLE
Relax importlib_metadata dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ packages = [
 python = "^3.7"
 
 # Packages for core library
-importlib_metadata = { version = "^1.0", python  = "<3.8" }
+importlib_metadata = { version = ">=1.0", python  = "<3.8" }  # Granta MI STK requires 3.4.0
 ansys-openapi-common = "*"  # TODO: Change to the released version
 ansys-grantami-bomanalytics-openapi = "0.1.0.dev15"  # TODO: Change to the released version
 


### PR DESCRIPTION
Closes #109 

The Granta MI Python STK has a pinned dependency on importlib_metadata: `importlib_metadata==3.4.0`. This is incompatible with the dependency on importlib_metadata here, which is set to `^1.0`, or `>=1, < 2`.

This PR relaxes the dependency to allow any version greater than the version we require to ensure compatibility with the Granta MI STK and any other packages that may require more specific versions of importlib_metadata.

This PR is the same as https://github.com/pyansys/openapi-common/pull/126.