### PR TITLE
Updates to support OIDC Authentication

### DIFF
--- a/src/ansys/grantami/bomanalytics/_connection.py
+++ b/src/ansys/grantami/bomanalytics/_connection.py
@@ -110,7 +110,7 @@ class Connection(ApiClientFactory):
         client = BomAnalyticsClient(
             session=self._session,
             servicelayer_url=self._base_servicelayer_url,
-            configuration=self._session_configuration
+            configuration=self._session_configuration,
         )
         client.setup_client(models)
         return client


### PR DESCRIPTION
Closes #108 

This PR extends the `ApiClientFactory` constructor to add a path to the base service layer URL before it is used for auth.

An alternative approach was to put this logic in the base `ApiClientFactory` class with a new optional str parameter called `auth_path`. I decided against this because we'd either have to rely on the `grantami-bomanalytics` users knowing to specify an auth path, or we'd have to extend the constructor anyway to add it in. It feels like a level of implementation detail that should be known to people writing packages that use `ansys-openapi-common`, but not to people who use the _those_ packages.

It occurs to me that the intended ways the `ApiClientFactory` and `ApiClient` classes can be extended/overridden is getting quite complex. We should document this somewhere in the `ansys-openapi-common` documentation.