### PR TITLE
Add concurrency group to CI/CD workflow

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -10,6 +10,10 @@ on:
       - main
   workflow_dispatch:
 
+concurrency:
+  group: integration-server
+  cancel-in-progress: false
+
 jobs:
   start_vm:
     name: Start Azure VM


### PR DESCRIPTION
This PR specifies a concurrency group for the CI/CD workflow, to ensure that multiple instances of the workflow do not 'complete' over the single integration test server.

Since there is only one server, this is specified as a fixed string.

It is in principle possible to specify this at the job level for more granularity. However, I don't think this will work in this situation because we are starting and stopping the server within a workflow. The workflow needs to remain as the atomic unit that checks out the server for use.

There is some redundancy here in terms of stopping and then immediately starting the VM, but I think trying to solve this would dramatically increase complexity.