### PR TITLE
Allow any version of bomanalytics-openapi

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ python = "^3.7"
 # Packages for core library
 importlib_metadata = { version = ">=1.0", python  = "<3.8" }  # Granta MI STK requires 3.4.0
 ansys-openapi-common = "*"  # TODO: Change to the released version
-ansys-grantami-bomanalytics-openapi = "0.1.0.dev15"  # TODO: Change to the released version
+ansys-grantami-bomanalytics-openapi = "*"  # TODO: Change to the released version
 
 # Common packages for test, examples, and docs
 jupyterlab = { version = "3.2.8", optional = true }


### PR DESCRIPTION
Closes #120 

Beta 4 has a strict dependency on 0.1.0.dev15, but the most recent (and probably only) artefact available in the repository is dev17, and therefore the package will not install.

This PR allows any version; we can then tighten up this dependency once bomanalytics-openapi is released.