### PR TITLE
DOC - Update intersphinx mapping to 3.11 not dev

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -45,7 +45,7 @@ autodoc_type_aliases = {"Yaml": "Yaml"}
 
 # Intersphinx mapping
 intersphinx_mapping = {
-    "python": ("https://docs.python.org/3", None),
+    "python": ("https://docs.python.org/3.11", None),
     "openapi-common": ("https://openapi.docs.pyansys.com", None),
     # kept here as an example
     # "scipy": ("https://docs.scipy.org/doc/scipy/reference", None),


### PR DESCRIPTION
The dev branch of python has renamed the builtin boolean reference, this breaks the docs build. Pin to 3.11 which works fine at present.