### PR TITLE
MAINT - Add scripts to automate backup and restoration of the test database

### DIFF
--- a/cicd/connection.py
+++ b/cicd/connection.py
@@ -1,0 +1,33 @@
+from importlib.metadata import version
+from typing import Optional
+
+from ansys.grantami.serverapi_openapi import models
+from ansys.openapi.common import SessionConfiguration, ApiClientFactory, generate_user_agent, ApiClient
+
+SERVICE_PATH = "/proxy/v1.svc"
+MI_AUTH_PATH = "/v1alpha/schema/mi-version"
+GRANTA_APPLICATION_NAME_HEADER = "PyGranta ServerAPI"
+
+
+class Connection(ApiClientFactory):
+    def __init__(self, api_url: str, session_configuration: Optional[SessionConfiguration] = None) -> None:
+        package_name = "ansys-grantami-serverapi-openapi"
+        ver = version(package_name)
+
+        self._full_api_url = api_url.strip("/") + SERVICE_PATH
+        auth_url = self._full_api_url + MI_AUTH_PATH
+
+        super().__init__(auth_url, session_configuration)
+        session_configuration = self._session_configuration
+        session_configuration.headers["X-Granta-ApplicationName"] = GRANTA_APPLICATION_NAME_HEADER
+        session_configuration.headers["User-Agent"] = generate_user_agent(package_name, ver)
+
+    def connect(self) -> ApiClient:
+        self._validate_builder()
+        client = ApiClient(
+            session=self._session,
+            api_url=self._full_api_url,
+            configuration=self._session_configuration,
+        )
+        client.setup_client(models)
+        return client

--- a/cicd/get_cleaned_db_entries.py
+++ b/cicd/get_cleaned_db_entries.py
@@ -1,3 +1,31 @@
+"""
+get_cleaned_db_entries.py
+-------------------------
+
+This script is the first step in the process for updating the test databases. It extracts the attributes and records
+from a current version into a format that can be used to generate an updated version.
+
+Set the value of MI_URL and DB_KEY as appropriate for your setup, the values of table_information, extra_attributes,
+and renamed_attributes should be OK for the current release.
+
+table_information
+=================
+
+table_information contains the name of the subset and the layout to be used. Attributes in the layout specified, and
+records in the subset specified, will be exported into the json data file
+
+extra_attributes
+================
+
+extra_attributes contains any attributes that should be copied across if they do not exist within the specified layout.
+
+renamed_attributes
+==================
+
+renamed_attributes contains a map of old name to new name for any attributes that have changed name between the current
+version of the database and the new version.
+"""
+
 import json
 import logging
 from pathlib import Path

--- a/cicd/get_cleaned_db_entries.py
+++ b/cicd/get_cleaned_db_entries.py
@@ -1,0 +1,127 @@
+import json
+import logging
+from pathlib import Path
+
+from GRANTA_MIScriptingToolkit import granta as mpy
+from ansys.grantami.serverapi_openapi import api, models
+
+from cicd.connection import Connection
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+ch = logging.StreamHandler()
+ch.setLevel(logging.INFO)
+formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
+ch.setFormatter(formatter)
+logger.addHandler(ch)
+
+MI_URL = "http://localhost/mi_servicelayer"
+DB_KEY = "MI_Restricted_Substances"
+OUTPUT_FILE_NAME = Path("./rs_data.json").resolve()
+
+logger.info(f"Connecting to MI at {MI_URL} with AutoLogon")
+s = mpy.Session(MI_URL, autologon=True)
+db = s.get_db(db_key=DB_KEY)
+api_client = Connection(api_url=MI_URL).with_autologon().connect()
+
+tables_api = api.SchemaTablesApi(api_client)
+attributes_api = api.SchemaAttributesApi(api_client)
+layouts_api = api.SchemaLayoutsApi(api_client)
+layout_sections_api = api.SchemaLayoutSectionsApi(api_client)
+
+table_information = {
+    "MaterialUniverse": {"layout": "All attributes", "subset": "All materials"},
+    "Materials - in house": {"layout": "All attributes", "subset": "All materials"},
+    "Products and parts": {"layout": "All attributes", "subset": "All products and parts"},
+    "Specifications": {"layout": "All properties", "subset": "All specifications"},
+    "Coatings": {"layout": "All properties", "subset": "All coatings"},
+    "Restricted Substances": {"layout": "Restricted substances", "subset": "All substances"},
+    "Legislations and Lists": {"layout": "Legislations", "subset": "All legislations"},
+}
+
+extra_attributes = {"Coatings": ["Coating Code"], "Legislations and Lists": ["Legislation ID", "Short title"]}
+
+renamed_attributes = {"Specifications": {"Chemical name": "Substance name"}}
+
+info = {}
+logger.info(f"Reading records and attributes from database '{DB_KEY}'")
+logger.info("Getting Table Information")
+tables: models.GrantaServerApiSchemaTablesInfo = tables_api.v1alpha_databases_database_key_tables_get(
+    database_key=DB_KEY
+)
+table_name_map = {table.name: table for table in tables.tables}
+for table_name, table_details in table_information.items():
+    logger.info(f"--Processing table '{table_name}'")
+    table = db.get_table(table_name)
+    layout_name = table_details["layout"]
+    subset_name = table_details["subset"]
+    logger.info(f"----Fetching attributes in layout '{layout_name}")
+    renamed_attributes_for_table = renamed_attributes.get(table_name, [])
+    table_info = table_name_map[table_name]
+    table_layouts: models.GrantaServerApiSchemaLayoutsLayoutsInfo = (
+        layouts_api.v1alpha_databases_database_key_tables_table_guid_layouts_get(
+            database_key=DB_KEY, table_guid=table_info.guid
+        )
+    )
+    layout_map = {layout.name: layout for layout in table_layouts.layouts}
+    layout_item = layout_map[layout_name]
+    sections_response: models.GrantaServerApiSchemaLayoutsLayoutSectionsInfo = (
+        layout_sections_api.v1alpha_databases_database_key_tables_table_guid_layouts_layout_guid_sections_get(
+            database_key=DB_KEY, table_guid=table_info.guid, layout_guid=layout_item.guid, show_full_detail=True
+        )
+    )
+    layout_info = [section.to_dict() for section in sections_response.layout_sections]
+    if table_name in extra_attributes:
+        # Add extra attribute information to a section in the layout
+        table_attributes: models.GrantaServerApiSchemaAttributesAttributesInfo = (
+            attributes_api.v1alpha_databases_database_key_tables_table_guid_attributes_get(
+                DB_KEY, table_guid=table_info.guid
+            )
+        )
+        attribute_name_map = {attribute.name: attribute for attribute in table_attributes.attributes}
+        added_items = []
+        relevant_attribute_names = extra_attributes[table_name]
+        for extra_attribute_name in relevant_attribute_names:
+            attribute_info: models.GrantaServerApiSchemaSlimEntitiesSlimAttribute = attribute_name_map[
+                extra_attribute_name
+            ]
+            added_items.append(
+                models.GrantaServerApiSchemaLayoutsLayoutAttributeItem(
+                    attribute_type=attribute_info.type,
+                    underlying_entity_guid=attribute_info.guid,
+                    name=attribute_info.name,
+                    meta_attributes=[],
+                    tabular_columns=None,
+                )
+            )
+        layout_info.append(
+            models.GrantaServerApiSchemaLayoutsFullLayoutSection(
+                name="Extra Attributes", section_items=added_items
+            ).to_dict()
+        )
+    if len(renamed_attributes_for_table) > 0:
+        logger.info(f"----Remapping attribute names")
+        for section in layout_info:
+            for item in section["section_items"]:
+                if item["name"] in renamed_attributes_for_table:
+                    new_name = renamed_attributes_for_table[item["name"]]
+                    logger.info(f"------Renaming attribute '{item['name']}' to '{new_name}")
+                    item["name"] = renamed_attributes_for_table[item["name"]]
+                if "tabular_columns" in item and item["tabular_columns"] is not None:
+                    for column in item["tabular_columns"]:
+                        if column["name"] in renamed_attributes_for_table:
+                            new_name = renamed_attributes_for_table[column["name"]]
+                            logger.info(
+                                f"------Renaming tabular column '{column['name']}' to '{new_name}' in attribute '{item['name']}'"  # noqa: E501
+                            )
+                            column["name"] = renamed_attributes_for_table[column["name"]]
+    logger.info(f"----Fetching records in subset '{subset_name}'")
+    records = [
+        (record.history_guid, record.record_guid)
+        for record in table.all_records(include_folders=True, include_generics=True)
+    ]
+    info[table_name] = {"layout": layout_info, "records": records}
+
+logger.info(f"Finished processing data, writing to {OUTPUT_FILE_NAME}")
+with open(OUTPUT_FILE_NAME, "w", encoding="utf8") as fp:
+    json.dump(info, fp)

--- a/cicd/modify_custom_rs_db.py
+++ b/cicd/modify_custom_rs_db.py
@@ -1,0 +1,173 @@
+import logging
+
+import GRANTA_MIScriptingToolkit as gdl
+
+from ansys.grantami.serverapi_openapi import api, models
+
+from cicd.connection import Connection
+from cicd.prepare_rs_db import TableBrowser
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+ch = logging.StreamHandler()
+ch.setLevel(logging.INFO)
+formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
+ch.setFormatter(formatter)
+logger.addHandler(ch)
+
+CUSTOM_DB_KEY = "MI_Restricted_Substances_Custom_Tables"
+
+if __name__ == "__main__":
+    logger.info("Renaming tables")
+    table_name_remapping = {
+        "MaterialUniverse": "My Material Universe",
+        "Materials - in house": "My Materials",
+        "Specifications": "specs",
+        "Products and parts": "Parts 'n' Products",
+        "Restricted Substances": "Chemicals",
+        "Coatings": "Coverings",
+    }
+
+    URL = "http://localhost/mi_servicelayer"
+    api_client = Connection(api_url=URL).with_autologon().connect()
+    gdl_session = gdl.GRANTA_MISession(url=URL, autoLogon=True)
+
+    database_client = api.SchemaDatabasesApi(api_client)
+
+    logger.info("Renaming Database")
+    database_info: models.GrantaServerApiSchemaDatabase = database_client.v1alpha_databases_database_key_get(
+        database_key=CUSTOM_DB_KEY
+    )
+    guid = database_info.guid
+    new_name = "Restricted Substances Custom Tables"
+    rename_request = models.GrantaServerApiSchemaUpdateDatabase(name=new_name)
+
+    database_client.v1alpha_databases_database_key_patch(database_key=CUSTOM_DB_KEY, body=rename_request)
+
+    table_browser = TableBrowser(api_client, logger)
+    custom_table_name_map = table_browser.get_table_name_guid_map(CUSTOM_DB_KEY)
+
+    for old_name, new_name in table_name_remapping.items():
+        table_guid = custom_table_name_map[old_name]
+        table_browser.update_table_name(db_key=CUSTOM_DB_KEY, table_guid=table_guid, new_table_name=new_name)
+
+    logger.info("Duplicating styrene record then withdrawing it. (TestActAsReadUser)")
+    data_import_service = gdl_session.dataImportService
+    substances_guid = custom_table_name_map["Chemicals"]
+    copy_import_record = gdl.ImportRecord(
+        existingRecord=gdl.RecordReference(
+            DBKey=CUSTOM_DB_KEY,
+            lookupValue=gdl.LookupValue(
+                attributeReference=gdl.AttributeReference(
+                    DBKey=CUSTOM_DB_KEY,
+                    name="CAS number",
+                    partialTableReference=gdl.PartialTableReference(tableGUID=substances_guid),
+                ),
+                attributeValue="100-42-5",
+            ),
+        ),
+        copyDestinationParent=gdl.RecordReference(
+            DBKey=CUSTOM_DB_KEY,
+            lookupValue=gdl.LookupValue(
+                attributeReference=gdl.AttributeReference(
+                    DBKey=CUSTOM_DB_KEY,
+                    name="CAS number",
+                    partialTableReference=gdl.PartialTableReference(tableGUID=substances_guid),
+                ),
+                attributeValue="7664-93-9",
+            ),
+        ),
+        recordName="Styrene Copy",
+        releaseRecord=True,
+        importRecordMode="Copy",
+    )
+    copy_request = gdl.SetRecordAttributesRequest(importRecords=[copy_import_record])
+    copy_response = data_import_service.SetRecordAttributes(copy_request)
+
+    record_reference = copy_response.recordsImported[0].recordReference
+    withdrawal_request = gdl.DeleteOrWithdrawIfLatestRecordVersionRequest(
+        deleteOrWithdrawRecords=[gdl.DeleteOrWithdrawRecord(recordReference=record_reference)]
+    )
+    delete_response = data_import_service.DeleteOrWithdrawIfLatestRecordVersion(withdrawal_request)
+
+    logger.info("Creating linked specifications. (TestSpecificationLinkDepth)")
+    specs_guid = custom_table_name_map["specs"]
+
+    tabular_type = gdl.TabularDataType()
+    tabular_type.AddColumn("Thickness")
+    new_row = tabular_type.CreateRow()
+
+    new_row.linkingValue = "Coating-203"
+    new_row.cells[0].data = gdl.RangeDataType(low=0.0508, high=0.127, unitSymbol="mm")
+    tabular_type.tabularDataRows.append(new_row)
+
+    spec_link_attribute = gdl.TabularDataType()
+    new_spec_row = spec_link_attribute.CreateRow()
+    new_spec_row.linkingValue = "MIL-DTL-53039,TypeI"
+    spec_link_attribute.tabularDataRows.append(new_spec_row)
+
+    import_spec_record = gdl.ImportRecord(
+        existingRecord=gdl.RecordReference(
+            DBKey=CUSTOM_DB_KEY,
+            lookupValue=gdl.LookupValue(
+                attributeReference=gdl.AttributeReference(
+                    DBKey=CUSTOM_DB_KEY,
+                    name="Specification ID",
+                    partialTableReference=gdl.PartialTableReference(tableGUID=specs_guid),
+                ),
+                attributeValue="MIL-DTL-53039",
+            ),
+        ),
+        recordName="MIL-DTL-53039, Type II",
+        releaseRecord=True,
+        importRecordMode="Create",
+        importAttributeValues=[
+            gdl.ImportAttributeValue(
+                attributeReference=gdl.AttributeReference(
+                    DBKey=CUSTOM_DB_KEY,
+                    name="Specification ID",
+                    partialTableReference=gdl.PartialTableReference(tableGUID=specs_guid),
+                ),
+                shortTextDataValue=gdl.ShortTextDataType(value="MIL-DTL-53039,TypeII"),
+            ),
+            gdl.ImportAttributeValue(
+                attributeReference=gdl.AttributeReference(
+                    pseudoAttribute=gdl.AttributeReference.MIPseudoAttributeReference.shortName
+                ),
+                shortTextDataValue=gdl.ShortTextDataType(value="MIL-DTL-53039, Type II"),
+            ),
+            gdl.ImportAttributeValue(
+                attributeReference=gdl.AttributeReference(
+                    DBKey=CUSTOM_DB_KEY,
+                    name="Coatings in this specification",
+                    partialTableReference=gdl.PartialTableReference(tableGUID=specs_guid),
+                ),
+                tabularDataValue=tabular_type,
+            ),
+            gdl.ImportAttributeValue(
+                attributeReference=gdl.AttributeReference(
+                    DBKey=CUSTOM_DB_KEY,
+                    name="Specifications in this specification",
+                    partialTableReference=gdl.PartialTableReference(tableGUID=specs_guid),
+                ),
+                tabularDataValue=spec_link_attribute,
+            ),
+            gdl.ImportAttributeValue(
+                attributeReference=gdl.AttributeReference(
+                    DBKey=CUSTOM_DB_KEY,
+                    name="Declaration type",
+                    partialTableReference=gdl.PartialTableReference(tableGUID=specs_guid),
+                ),
+                discreteDataValue=gdl.DiscreteDataType(discreteValues=[gdl.DiscreteValue(value="Generic data")]),
+            ),
+        ],
+        subsetReferences=[
+            gdl.SubsetReference(
+                DBKey=CUSTOM_DB_KEY,
+                name="All specifications",
+                partialTableReference=gdl.PartialTableReference(tableGUID=specs_guid),
+            )
+        ],
+    )
+    import_spec_request = gdl.SetRecordAttributesRequest(importRecords=[import_spec_record])
+    import_spec_response = data_import_service.SetRecordAttributes(import_spec_request)

--- a/cicd/modify_custom_rs_db.py
+++ b/cicd/modify_custom_rs_db.py
@@ -1,3 +1,25 @@
+"""
+modify_custom_rs_db.py
+-------------------------
+
+This script is the last step in creating new test databases. It modifies a cut down database, changing the name,
+renaming tables, and adding any extra records required for specific tests.
+
+Set the URL as appropriate for your database server.
+
+The first operation is to rename the database, this has no practical purpose, but it makes it easier to see which which
+database is which in log files.
+
+Secondly the tables are renamed, this is required to test that the custom table name feature of the API works as
+expected. If you change the names of the tables in the test setup you will need to change the names here as well.
+
+The script then adds a copy of the styrene record as a child of Sulphuric Acid and withdraws it, this allows us to test
+that the API returns a warning for us if more than one record matches a specific CAS number.
+
+Finally, we create a new record in the specifications table which is linked to another, this allows us to test that the
+specification depth parameter works as expected.
+"""
+
 import logging
 
 import GRANTA_MIScriptingToolkit as gdl

--- a/cicd/prepare_rs_db.py
+++ b/cicd/prepare_rs_db.py
@@ -1,3 +1,17 @@
+"""
+prepare_rs_db.py
+-------------------------
+
+This script is the second step in the process of creating a new test database. It takes the json file output from
+get_cleaned_db_entries.py and creates a new layout and subset with the required attributes and records.
+
+It uses both the Ansys Granta MI Scripting Toolkit and the ansys-grantami-serverapi-openapi package to manipulate the
+schema and records in the database.
+
+Set the URL appropriately for your system and restore two copies of the released Restricted Substances database, change
+one database key to `MI_Restricted_Substances_Custom_Tables`, then run this script.
+"""
+
 import json
 import logging
 from pathlib import Path

--- a/cicd/prepare_rs_db.py
+++ b/cicd/prepare_rs_db.py
@@ -1,0 +1,357 @@
+import json
+import logging
+from pathlib import Path
+from typing import Mapping, Iterable, Tuple
+
+from ansys.grantami.serverapi_openapi import api, models
+import GRANTA_MIScriptingToolkit as gdl
+from ansys.openapi.common import ApiClient
+
+from cicd.connection import Connection
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+ch = logging.StreamHandler()
+ch.setLevel(logging.INFO)
+formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
+ch.setFormatter(formatter)
+logger.addHandler(ch)
+
+LAYOUT_TO_PRESERVE = "AttributesToKeep"
+SUBSET_TO_PRESERVE = "RecordsToKeep"
+
+INPUT_FILE_NAME = Path("./rs_data.json").resolve()
+
+
+class ServerApiClient:
+    def __init__(self, api_client: ApiClient, logger: logging.Logger) -> None:
+        self._client = api_client
+        self.logger = logger
+
+
+class TableBrowser(ServerApiClient):
+    def get_table_name_guid_map(self, db_key: str) -> Mapping[str, str]:
+        tables_api = api.SchemaTablesApi(self._client)
+        self.logger.info(f"Getting Table Information for database '{db_key}'")
+        tables: models.GrantaServerApiSchemaTablesInfo = tables_api.v1alpha_databases_database_key_tables_get(
+            database_key=db_key
+        )
+        table_name_map = {table.name: table.guid for table in tables.tables}
+        logger.info(f"Fetched {len(table_name_map)} tables")
+        for name, guid in table_name_map.items():
+            logger.debug(f"Name: '{name}' - Guid: '{guid}'")
+        return table_name_map
+
+    def update_table_name(self, db_key: str, table_guid: str, new_table_name: str) -> None:
+        tables_api = api.SchemaTablesApi(self._client)
+        self.logger.info(f"Updating Table - {db_key}:{table_guid} with name '{new_table_name}'")
+        patch_request = models.GrantaServerApiSchemaUpdateTable(name=new_table_name)
+        tables_api.v1alpha_databases_database_key_tables_table_guid_patch(
+            database_key=db_key, table_guid=table_guid, body=patch_request
+        )
+
+
+class TableLayoutApplier(ServerApiClient):
+    def __init__(self, api_client: ApiClient, logger: logging.Logger, db_key: str, table_guid: str) -> None:
+        super().__init__(api_client, logger)
+        self._attributes_api = api.SchemaAttributesApi(self._client)
+        self._layouts_api = api.SchemaLayoutsApi(self._client)
+        self._layout_sections_api = api.SchemaLayoutSectionsApi(self._client)
+        table_attributes: models.GrantaServerApiSchemaAttributesAttributesInfo = (
+            self._attributes_api.v1alpha_databases_database_key_tables_table_guid_attributes_get(
+                database_key=db_key, table_guid=table_guid
+            )
+        )
+        self._db_key = db_key
+        self._table_guid = table_guid
+        self._attribute_name_map: Mapping[str, str] = {
+            attribute.name: attribute.guid for attribute in table_attributes.attributes
+        }
+
+    def get_layout_name_guid_map(self) -> Mapping[str, str]:
+        self.logger.info(f"Getting Layout Information for database '{self._db_key}' in table '{self._table_guid}'")
+        layouts: models.GrantaServerApiSchemaLayoutsLayoutsInfo = (
+            self._layouts_api.v1alpha_databases_database_key_tables_table_guid_layouts_get(
+                database_key=self._db_key, table_guid=self._table_guid
+            )
+        )
+        layouts_map = {layout.name: layout.guid for layout in layouts.layouts}
+        return layouts_map
+
+    def delete_layout(self, layout_guid: str) -> None:
+        logger.info(f"Deleting layout '{layout_guid}'")
+        self._layouts_api.v1alpha_databases_database_key_tables_table_guid_layouts_layout_guid_delete(
+            database_key=self._db_key, table_guid=self._table_guid, layout_guid=layout_guid
+        )
+
+    def create_layout(self, layout_name: str) -> str:
+        logger.info(f"Creating new layout '{layout_name}'")
+        layout_request = models.GrantaServerApiSchemaLayoutsUpdateLayout(name=layout_name)
+        layout_response: models.GrantaServerApiSchemaSlimEntitiesSlimLayout = (
+            self._layouts_api.v1alpha_databases_database_key_tables_table_guid_layouts_post(
+                database_key=self._db_key, table_guid=self._table_guid, body=layout_request
+            )
+        )
+        return layout_response.guid
+
+    def create_layout_section(self, layout_guid: str, section_name: str) -> str:
+        logger.info(f"Creating new layout section '{section_name}' in layout '{layout_guid}'")
+        section_request = models.GrantaServerApiSchemaSlimEntitiesSlimLayoutSection(name=section_name)
+        section_response: models.GrantaServerApiSchemaSlimEntitiesSlimLayoutSection = self._layout_sections_api.v1alpha_databases_database_key_tables_table_guid_layouts_layout_guid_sections_post(  # noqa: E501
+            database_key=self._db_key, table_guid=self._table_guid, layout_guid=layout_guid, body=section_request
+        )
+        return section_response.guid
+
+    def add_layout_section_item(self, layout_guid: str, layout_section_guid: str, item_information: Mapping):
+        logger.info(
+            f"Adding new item '{item_information['name']}' to layout section '{layout_section_guid}' in layout '{layout_guid}'"  # noqa: E501
+        )
+        new_section_item = self._process_layout_item(item_information)
+        self._layout_sections_api.v1alpha_databases_database_key_tables_table_guid_layouts_layout_guid_sections_section_guid_items_post(  # noqa: E501
+            database_key=self._db_key,
+            table_guid=self._table_guid,
+            layout_guid=layout_guid,
+            section_guid=layout_section_guid,
+            body=new_section_item,
+        )
+
+    def _process_layout_item(self, item_information: Mapping) -> models.GrantaServerApiSchemaLayoutsNewLayoutItem:
+        if item_information["item_type"] == "attribute":
+            return self._process_attribute(item_information)
+        elif item_information["item_type"] == "link":
+            if item_information["link_type"] == "associationChain":
+                return self._process_association_chain(item_information)
+        raise NotImplementedError("Other layout items are not supported yet...")
+
+    def _process_association_chain(self, layout_item):
+        item_name = layout_item["name"]
+        logger.info(f"--Association Chain - '{item_name}'")
+        links = self._process_association_chain_link(layout_item)
+        return models.GrantaServerApiSchemaLayoutsNewLayoutAssociationChainItem(
+            association_chain_name=item_name, association_chain_links=links
+        )
+
+    def _process_association_chain_link(self, chain_link):
+        links = [
+            models.GrantaServerApiSchemaLayoutsNewLayoutAssociationChainLink(
+                forwards=chain_link["forwards"], tabular_attribute_guid=chain_link["underlying_entity_guid"]
+            )
+        ]
+        logger.info(f"----Link - {chain_link['name']}")
+        if chain_link["next_link"] is not None:
+            links.extend(self._process_association_chain_link(chain_link["next_link"]))
+        return links
+
+    def _process_attribute(self, layout_item: Mapping):
+        attribute_name = layout_item["name"]
+        logger.info(f"--Attribute - '{attribute_name}'")
+        meta_names = layout_item["meta_attributes"]
+        attribute_guid = self._attribute_name_map[attribute_name]
+
+        new_section_item = models.GrantaServerApiSchemaLayoutsNewLayoutAttributeItem(attribute_guid=attribute_guid)
+        if layout_item["tabular_columns"] is not None:
+            detailed_attribute_info: models.GrantaServerApiSchemaAttributesTabularAttribute = (
+                self._attributes_api.v1alpha_databases_database_key_tables_table_guid_attributes_attribute_guid_get(
+                    database_key=self._db_key, table_guid=self._table_guid, attribute_guid=attribute_guid
+                )
+            )
+            column_map = {column.name: column for column in detailed_attribute_info.tabular_columns}
+            columns = []
+            for column_item in layout_item["tabular_columns"]:
+                columns.append(column_map[column_item["name"]].guid)
+            new_section_item.tabular_column_guids = columns
+        if len(meta_names) > 0:
+            logger.info("--Meta-attributes")
+            metas = []
+            meta_response: models.GrantaServerApiSchemaAttributesAttributesInfo = self._attributes_api.v1alpha_databases_database_key_tables_table_guid_attributes_attribute_guid_meta_attributes_get(  # noqa: E501
+                database_key=self._db_key, table_guid=self._table_guid, attribute_guid=attribute_guid
+            )
+            meta_map = {meta.name: meta.guid for meta in meta_response.attributes}
+            for meta_name in meta_names:
+                logger.info(f"----{meta_name}")
+                meta_item = meta_map[meta_name]
+                metas.append(models.GrantaServerApiSchemaLayoutsNewLayoutAttributeItem(attribute_guid=meta_item.guid))
+            new_section_item.meta_attributes = metas
+        return new_section_item
+
+
+class SubsetCreator(ServerApiClient):
+    def get_subset_name_guid_map(self, db_key: str, table_guid: str) -> Mapping[str, str]:
+        subsets_api = api.SchemaSubsetsApi(self._client)
+        self.logger.info(f"Getting Subset Information for database '{db_key}' in table '{table_guid}'")
+        subsets: models.GrantaServerApiSchemaSubsetsInfo = (
+            subsets_api.v1alpha_databases_database_key_tables_table_guid_subsets_get(
+                database_key=db_key, table_guid=table_guid
+            )
+        )
+        subsets_map = {subset.name: subset.guid for subset in subsets.subsets}
+        return subsets_map
+
+    def delete_subset(self, db_key: str, table_guid: str, subset_guid: str):
+        subsets_api = api.SchemaSubsetsApi(self._client)
+        self.logger.info(f"Deleting subset '{subset_guid}'")
+        subsets_api.v1alpha_databases_database_key_tables_table_guid_subsets_subset_guid_delete(
+            database_key=db_key, table_guid=table_guid, subset_guid=subset_guid
+        )
+
+    def create_subset(self, db_key: str, table_guid: str, subset_name: str) -> str:
+        subsets_api = api.SchemaSubsetsApi(self._client)
+        self.logger.info(f"Creating new subset '{subset_name}'")
+        subset_request = models.GrantaServerApiSchemaUpdateSubset(name=subset_name)
+        subset_response: models.GrantaServerApiSchemaSubset = (
+            subsets_api.v1alpha_databases_database_key_tables_table_guid_subsets_post(
+                database_key=db_key, table_guid=table_guid, body=subset_request
+            )
+        )
+        return subset_response.guid
+
+
+class SubsetPopulater:
+    def __init__(self, gdl_session: gdl.GRANTA_MISession, logger: logging.Logger):
+        self._session = gdl_session
+        self._logger = logger
+        self._data_import_session = self._session.dataImportService
+        self._data_export_session = self._session.dataExportService
+
+    def _get_subsets(
+        self, db_key: str, record_identifiers: Iterable[Tuple[str, str]]
+    ) -> Iterable[Iterable[gdl.SubsetReference]]:
+        self._logger.info("Fetching subset membership for records")
+        record_references = [
+            gdl.RecordReference(DBKey=db_key, historyGUID=history_guid, recordGUID=record_guid, recordUID=str(uid))
+            for uid, (history_guid, record_guid) in enumerate(record_identifiers)
+        ]
+        subsets_request = gdl.GetRecordAttributesByRefRequest(
+            attributeReferences=[
+                gdl.AttributeReference(
+                    DBKey=db_key, pseudoAttribute=gdl.AttributeReference.MIPseudoAttributeReference.subsets
+                )
+            ],
+            recordReferences=record_references,
+        )
+        subsets_response = self._data_export_session.GetRecordAttributesByRef(subsets_request)
+        self._logger.info(f"Fetched subset membership for {len(record_references)} records")
+
+        items = subsets_response.recordData
+        items.sort(key=lambda x: x.recordReference.recordUID)
+        existing_subsets = [
+            [subset.subset for subset in item.attributeValues[0].subsetsDataType.namedSubsets] for item in items
+        ]
+        return existing_subsets
+
+    def add_records_to_subset(
+        self, db_key: str, record_identifiers: Iterable[Tuple[str, str]], table_guid: str, new_subset_name: str
+    ) -> None:
+        existing_subsets = self._get_subsets(db_key, record_identifiers)
+
+        import_records = []
+        for (history_guid, record_guid), existing_subsets in zip(record_identifiers, existing_subsets):
+            new_subsets = existing_subsets
+            new_subsets.append(
+                gdl.SubsetReference(
+                    DBKey=db_key,
+                    name=new_subset_name,
+                    partialTableReference=gdl.PartialTableReference(tableGUID=table_guid),
+                )
+            )
+            import_record = gdl.ImportRecord(
+                existingRecord=gdl.RecordReference(DBKey=db_key, historyGUID=history_guid, recordGUID=record_guid),
+                subsetReferences=new_subsets,
+                releaseRecord=True,
+            )
+            import_records.append(import_record)
+        self._logger.info("Adding specified records to the new subset")
+        import_request = gdl.SetRecordAttributesRequest(importRecords=import_records)
+        self._data_import_session.SetRecordAttributes(import_request)
+
+
+def process_database(
+    database_key: str, api_client: ApiClient, gdl_session: gdl.GRANTA_MISession, table_name_map: Mapping[str, str]
+):
+    for table_name, table_data in input_data.items():
+        table_guid = table_name_map.get(table_name, None)
+        logger.info(f"Processing table '{table_name}'")
+        if table_guid is None:
+            message = [
+                f"No table with name {table_name} in database... Perhaps the schema has changed?",
+                "Tables available:",
+            ]
+            for available_table_name in table_name_map:
+                message.append(f"  {available_table_name}")
+            raise KeyError("\n".join(message))
+
+        logger.info("Checking whether subset already exists")
+        subsets_creator = SubsetCreator(api_client, logger)
+        existing_subsets = subsets_creator.get_subset_name_guid_map(db_key=database_key, table_guid=table_guid)
+        if SUBSET_TO_PRESERVE in existing_subsets:
+            logger.info("Deleting existing subset")
+            subsets_creator.delete_subset(
+                db_key=database_key, table_guid=table_guid, subset_guid=existing_subsets[SUBSET_TO_PRESERVE]
+            )
+
+        logger.info("Creating subset for use")
+        created_subset_guid = subsets_creator.create_subset(
+            db_key=database_key, table_guid=table_guid, subset_name=SUBSET_TO_PRESERVE
+        )
+        logger.info(f"Created subset {SUBSET_TO_PRESERVE} with GUID {created_subset_guid}")
+
+        logger.info("Checking whether layout already exists")
+        table_layout_provider = TableLayoutApplier(api_client, logger, db_key=database_key, table_guid=table_guid)
+        layout_name_guid_map = table_layout_provider.get_layout_name_guid_map()
+        if LAYOUT_TO_PRESERVE in layout_name_guid_map:
+            logger.info("Deleting existing layout")
+            table_layout_provider.delete_layout(layout_name_guid_map[LAYOUT_TO_PRESERVE])
+
+        logger.info("Creating layout to preserve attributes")
+        new_layout_guid = table_layout_provider.create_layout(LAYOUT_TO_PRESERVE)
+
+        logger.info("Populating layout sections")
+        for section in table_data["layout"]:
+            section_name = section["name"]
+            section_items = section["section_items"]
+            logger.info(f"Creating layout section '{section_name}'")
+            section_guid = table_layout_provider.create_layout_section(
+                layout_guid=new_layout_guid, section_name=section_name
+            )
+            logger.info("Populating with attributes")
+
+            for section_item in section_items:
+                table_layout_provider.add_layout_section_item(
+                    layout_guid=new_layout_guid, layout_section_guid=section_guid, item_information=section_item
+                )
+
+        logging.info("Schema changes completed, populating subset")
+        subset_populater = SubsetPopulater(gdl_session, logger)
+        subset_populater.add_records_to_subset(
+            db_key=database_key,
+            record_identifiers=table_data["records"],
+            table_guid=table_guid,
+            new_subset_name=SUBSET_TO_PRESERVE,
+        )
+
+
+if __name__ == "__main__":
+    # Update URL and connection method for your system
+    URL = "http://localhost/dev_servicelayer"
+    api_client = Connection(api_url=URL).with_autologon().connect()
+    gdl_session = gdl.GRANTA_MISession(url=URL, autoLogon=True)
+
+    logger.info("Loading saved RS information...")
+    if not INPUT_FILE_NAME.exists():
+        logger.error("No saved data available. Run 'get_cleaned_db_entries.py' against an existing test DB first")
+        exit(1)
+    with open(INPUT_FILE_NAME, "r", encoding="utf8") as fp:
+        input_data = json.load(fp)
+
+    table_browser = TableBrowser(api_client, logger)
+    logger.info("Getting Table Information")
+
+    vanilla_db_key = "MI_Restricted_Substances"
+    vanilla_table_name_map = table_browser.get_table_name_guid_map(vanilla_db_key)
+    process_database(vanilla_db_key, api_client, gdl_session, vanilla_table_name_map)
+
+    custom_db_key = "MI_Restricted_Substances_Custom_Tables"
+    custom_table_name_map = table_browser.get_table_name_guid_map(custom_db_key)
+    process_database(custom_db_key, api_client, gdl_session, custom_table_name_map)
+
+    logger.info("All done")

--- a/cicd/prepare_rs_db.py
+++ b/cicd/prepare_rs_db.py
@@ -332,7 +332,7 @@ def process_database(
 
 if __name__ == "__main__":
     # Update URL and connection method for your system
-    URL = "http://localhost/dev_servicelayer"
+    URL = "http://localhost/mi_servicelayer"
     api_client = Connection(api_url=URL).with_autologon().connect()
     gdl_session = gdl.GRANTA_MISession(url=URL, autoLogon=True)
 


### PR DESCRIPTION
This PR adds a collection of scripts:

1. connection.py provides a serverapi connection client following the docs from serverapi-openapi
2. get_cleaned_db_entries.py collects attribute names and records in a subset from a database, it also performs basic mapping for extra attributes to include and those that have had their names changes
3. prepare_rs_db.py applies these changes, creating a subset and a layout with the appropriate things populated, ready for the database to be cleaned
4. modify_custom_rs_db.py adds extra records for tests and custom table names

These scripts have been tested with the current release and they produce a DB that works with the test suite.