### PR TITLE
FIX - Update records

### DIFF
--- a/cicd/prepare_rs_db.py
+++ b/cicd/prepare_rs_db.py
@@ -272,6 +272,7 @@ class SubsetPopulater:
                 existingRecord=gdl.RecordReference(DBKey=db_key, historyGUID=history_guid, recordGUID=record_guid),
                 subsetReferences=new_subsets,
                 releaseRecord=True,
+                importRecordMode="Update",
             )
             import_records.append(import_record)
         self._logger.info("Adding specified records to the new subset")


### PR DESCRIPTION
Small change to only update records, not create new ones when adding to subsets. This should prevent spurious addition of blank records when cleaning the DB.