### PR TITLE
CI - Minor script fixes

### DIFF
--- a/cicd/modify_custom_rs_db.py
+++ b/cicd/modify_custom_rs_db.py
@@ -75,7 +75,7 @@ if __name__ == "__main__":
 
     logger.info("Duplicating styrene record then withdrawing it. (TestActAsReadUser)")
     data_import_service = gdl_session.dataImportService
-    substances_guid = custom_table_name_map["Chemicals"]
+    substances_guid = custom_table_name_map["Restricted Substances"]
     copy_import_record = gdl.ImportRecord(
         existingRecord=gdl.RecordReference(
             DBKey=CUSTOM_DB_KEY,

--- a/cicd/prepare_rs_db.py
+++ b/cicd/prepare_rs_db.py
@@ -272,6 +272,7 @@ class SubsetPopulater:
                 existingRecord=gdl.RecordReference(DBKey=db_key, historyGUID=history_guid, recordGUID=record_guid),
                 subsetReferences=new_subsets,
                 releaseRecord=True,
+                importRecordMode="Update",
             )
             import_records.append(import_record)
         self._logger.info("Adding specified records to the new subset")

--- a/cicd/prepare_rs_db.py
+++ b/cicd/prepare_rs_db.py
@@ -269,7 +269,7 @@ class SubsetPopulater:
                 )
             )
             import_record = gdl.ImportRecord(
-                existingRecord=gdl.RecordReference(DBKey=db_key, historyGUID=history_guid, recordGUID=record_guid),
+                existingRecord=gdl.RecordReference(DBKey=db_key, historyGUID=history_guid),
                 subsetReferences=new_subsets,
                 releaseRecord=True,
                 importRecordMode="Update",


### PR DESCRIPTION
Couple of minor fixes:
1. Fix name of database in modify_custom_rs_db.py - we don't fetch tables after renaming, so we need the old name
2. Only use history GUID to avoid issues with new versions