### PR TITLE
CI - Add new record to the default subset

### DIFF
--- a/cicd/modify_custom_rs_db.py
+++ b/cicd/modify_custom_rs_db.py
@@ -99,6 +99,13 @@ if __name__ == "__main__":
                 attributeValue="7664-93-9",
             ),
         ),
+        subsetReferences=[
+            gdl.SubsetReference(
+                DBKey=CUSTOM_DB_KEY,
+                name="All Substances",
+                partialTableReference=gdl.PartialTableReference(tableGUID=substances_guid),
+            )
+        ],
         recordName="Styrene Copy",
         releaseRecord=True,
         importRecordMode="Copy",


### PR DESCRIPTION
We need to add the copied record to the default subset to make the test work as intended.