### PR TITLE
#291 Fix EU REACH, and some other miscellaneous documentation improvements

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,7 +49,7 @@ Here's a brief example of how to use PyGranta BoM Analytics:
     >>> query = (
     ...     queries.MaterialImpactedSubstancesQuery()
     ...     .with_material_ids(['plastic-abs-pvc-flame'])
-    ...     .with_legislations(['REACH - The Candidate List'])
+    ...     .with_legislations(['EU REACH - The Candidate List'])
     ... )
 
     # Print out the result from the query.

--- a/doc/source/index/quick_code.rst
+++ b/doc/source/index/quick_code.rst
@@ -13,7 +13,7 @@ high concern) in an ABS/PVC blend:
     >>> query = (
     ...     queries.MaterialImpactedSubstancesQuery()
     ...     .with_material_ids(['plastic-abs-pvc-flame'])
-    ...     .with_legislations(['REACH - The Candidate List'])
+    ...     .with_legislations(['EU REACH - The Candidate List'])
     ... )
     >>> result = cxn.run(query)
     >>> pprint(result.impacted_substances)

--- a/doc/source/index/quick_code.rst
+++ b/doc/source/index/quick_code.rst
@@ -8,7 +8,7 @@ high concern) in an ABS/PVC blend:
 
     >>> from pprint import pprint
     >>> from ansys.grantami.bomanalytics import Connection, queries
-    >>> cxn = Connection(servicelayer_url="http://localhost/mi_servicelayer") \
+    >>> cxn = Connection(servicelayer_url="http://my_mi_server/mi_servicelayer") \
     ...     .with_autologon().connect()
     >>> query = (
     ...     queries.MaterialImpactedSubstancesQuery()

--- a/examples/0_Getting_started.py
+++ b/examples/0_Getting_started.py
@@ -82,10 +82,10 @@ query
 # Note that because the ``MaterialImpactedSubstancesQuery`` object has a fluent interface, you receive the same object
 # back that you started with, but with the material IDs added.
 #
-# Finally, add the legislation to the query.
+# Finally, add the legislation to the query. Legislations are identified by their ``Short title`` attribute.
 
 # + tags=[]
-query = query.with_legislations(["REACH - The Candidate List"])
+query = query.with_legislations(["EU REACH - The Candidate List"])
 query
 # -
 
@@ -93,7 +93,7 @@ query
 # consolidate the cells above into a single step:
 
 # + tags=[]
-query = queries.MaterialImpactedSubstancesQuery().with_material_ids(["plastic-abs-high-impact"]).with_legislations(["REACH - The Candidate List"])  # noqa: E501
+query = queries.MaterialImpactedSubstancesQuery().with_material_ids(["plastic-abs-high-impact"]).with_legislations(["EU REACH - The Candidate List"])  # noqa: E501
 query
 # -
 
@@ -105,7 +105,7 @@ query
 query = (
     queries.MaterialImpactedSubstancesQuery()
     .with_material_ids(["plastic-abs-high-impact"])
-    .with_legislations(["REACH - The Candidate List"])
+    .with_legislations(["EU REACH - The Candidate List"])
 )
 query
 # -

--- a/examples/1_Impacted_Substances_Queries/1-1_Materials_impacted_substances.py
+++ b/examples/1_Impacted_Substances_Queries/1-1_Materials_impacted_substances.py
@@ -43,7 +43,7 @@ cxn = Connection(server_url).with_credentials("user_name", "password").connect()
 PPS_ID = "plastic-pps-generalpurpose"
 PC_ID = "plastic-pc-20carbonfiber"
 SIN_LIST = "The SIN List 2.1 (Substitute It Now!)"
-REACH = "REACH - The Candidate List"
+REACH = "EU REACH - The Candidate List"
 # -
 
 # Next import the ``queries`` module and build the query with the references in the previous cell.

--- a/examples/1_Impacted_Substances_Queries/1-2_Parts_impacted_substances.py
+++ b/examples/1_Impacted_Substances_Queries/1-2_Parts_impacted_substances.py
@@ -54,7 +54,7 @@ cxn = Connection(server_url).with_credentials("user_name", "password").connect()
 DRILL = "DRILL"
 WING = "asm_flap_mating"
 SIN_LIST = "The SIN List 2.1 (Substitute It Now!)"
-REACH = "REACH - The Candidate List"
+REACH = "EU REACH - The Candidate List"
 # -
 
 # Next, import the ``queries`` module and build the query with the references in the previous cell.

--- a/examples/2_Compliance_Queries/2-1_Substance_compliance.py
+++ b/examples/2_Compliance_Queries/2-1_Substance_compliance.py
@@ -16,7 +16,7 @@
 # # Performing a Substance Compliance Query
 
 # A Substance Compliance Query determines whether one or more substances are compliant with the specified indicators.
-# This example checks several materials for substances included on two watch lists ("REACH - The Candidate List", and
+# This example checks several materials for substances included on two watch lists ("EU REACH - The Candidate List", and
 # "The SIN List 2.1"), specifying substance amounts and thresholds for compliance.
 
 # ## Connecting to Granta MI
@@ -51,7 +51,7 @@ from ansys.grantami.bomanalytics import indicators
 
 svhc = indicators.WatchListIndicator(
     name="SVHC",
-    legislation_names=["REACH - The Candidate List"],
+    legislation_names=["EU REACH - The Candidate List"],
     default_threshold_percentage=0.1,
 )
 sin = indicators.WatchListIndicator(

--- a/examples/2_Compliance_Queries/2-2_Material_compliance.py
+++ b/examples/2_Compliance_Queries/2-2_Material_compliance.py
@@ -51,7 +51,7 @@ from ansys.grantami.bomanalytics import indicators
 
 svhc = indicators.WatchListIndicator(
     name="SVHC",
-    legislation_names=["REACH - The Candidate List"],
+    legislation_names=["EU REACH - The Candidate List"],
     default_threshold_percentage=0.1,
 )
 sin = indicators.WatchListIndicator(

--- a/examples/2_Compliance_Queries/2-3_Part_compliance.py
+++ b/examples/2_Compliance_Queries/2-3_Part_compliance.py
@@ -51,7 +51,7 @@ from ansys.grantami.bomanalytics import indicators
 
 svhc = indicators.WatchListIndicator(
     name="SVHC",
-    legislation_names=["REACH - The Candidate List"],
+    legislation_names=["EU REACH - The Candidate List"],
     default_threshold_percentage=0.1,
 )
 sin = indicators.WatchListIndicator(

--- a/examples/3_Advanced_Topics/3-1_Working_with_XML_BoMs.py
+++ b/examples/3_Advanced_Topics/3-1_Working_with_XML_BoMs.py
@@ -128,7 +128,7 @@ from ansys.grantami.bomanalytics import indicators
 
 svhc = indicators.WatchListIndicator(
     name="SVHC",
-    legislation_names=["REACH - The Candidate List"],
+    legislation_names=["EU REACH - The Candidate List"],
     default_threshold_percentage=0.1,
 )
 compliance_query = (

--- a/examples/3_Advanced_Topics/3-2_Dealing_with_external_data_sources.py
+++ b/examples/3_Advanced_Topics/3-2_Dealing_with_external_data_sources.py
@@ -78,7 +78,7 @@ server_url = "http://my_grantami_server/mi_servicelayer"
 cxn = Connection(server_url).with_credentials("user_name", "password").connect()
 svhc = indicators.WatchListIndicator(
     name="SVHC",
-    legislation_names=["REACH - The Candidate List"],
+    legislation_names=["EU REACH - The Candidate List"],
     default_threshold_percentage=0.1,
 )
 mat_query = (

--- a/examples/3_Advanced_Topics/3-4_Writing_compliance_results_to_a_dataframe.py
+++ b/examples/3_Advanced_Topics/3-4_Writing_compliance_results_to_a_dataframe.py
@@ -33,7 +33,7 @@ server_url = "http://my_grantami_server/mi_servicelayer"
 cxn = Connection(server_url).with_credentials("user_name", "password").connect()
 svhc = indicators.WatchListIndicator(
     name="SVHC",
-    legislation_names=["REACH - The Candidate List"],
+    legislation_names=["EU REACH - The Candidate List"],
     default_threshold_percentage=0.1,
 )
 part_query = (

--- a/src/ansys/grantami/bomanalytics/_connection.py
+++ b/src/ansys/grantami/bomanalytics/_connection.py
@@ -177,7 +177,7 @@ class Connection(ApiClientFactory):
         except ApiException as e:
             if e.status_code == 404:
                 raise ConnectionError(
-                    "Cannot find the BoM Analytics service in Granta MI Service Layer. Ensure a compatible version of"
+                    "Cannot find the BoM Analytics service in Granta MI Service Layer. Ensure a compatible version of "
                     "the Restricted Substances Reports are available on the server and try again."
                 )
             else:
@@ -319,7 +319,7 @@ class BomAnalyticsClient(ApiClient):
 
         Examples
         --------
-        >>> cxn = Connection("http://localhost/mi_servicelayer").with_autologon().connect()
+        >>> cxn = Connection("http://my_mi_server/mi_servicelayer").with_autologon().connect()
         >>> cxn.set_database_details(database_key = "MY_RS_DB",
         ...                          in_house_materials_table_name = "My Materials")
         """

--- a/src/ansys/grantami/bomanalytics/_query_results.py
+++ b/src/ansys/grantami/bomanalytics/_query_results.py
@@ -176,7 +176,7 @@ class ImpactedSubstancesBaseClass(ResultBaseClass):
         --------
         >>> result: MaterialImpactedSubstancesQueryResult
         >>> result.impacted_substances_by_legislation
-        {'REACH - The Candidate List': [
+        {'EU REACH - The Candidate List': [
             <ImpactedSubstance: {"cas_number": 90481-04-2}>, ...]
         }
         """

--- a/src/ansys/grantami/bomanalytics/indicators.py
+++ b/src/ansys/grantami/bomanalytics/indicators.py
@@ -371,7 +371,8 @@ class RoHSIndicator(_Indicator):
     name : str
         Name of the indicator that is to identify the indicator in the query result.
     legislation_names : list[str]
-        Legislations against which compliance will be determined.
+        Legislations against which compliance will be determined. Legislations are identified based
+        on their ``Short title`` attribute value.
     default_threshold_percentage : float, optional
         Concentration of substance that is to be determined to be non-compliant. The default is ``None``.
         This parameter is only used if the legislation doesn't define a specific threshold for the substance.
@@ -456,7 +457,8 @@ class WatchListIndicator(_Indicator):
     name : str
         Name of the indicator that is used to identify the indicator in the query result.
     legislation_names : list[str]
-        Legislations against which compliance is to be determined.
+        Legislations against which compliance is to be determined. Legislations are identified based
+        on their ``Short title`` attribute value.
     default_threshold_percentage : float, optional
         Percentage of substance concentration that is to be determined to be non-compliant. The default is ``None``.
         This parameter is only used if the legislation doesn't define a specific threshold for the substance.

--- a/src/ansys/grantami/bomanalytics/queries.py
+++ b/src/ansys/grantami/bomanalytics/queries.py
@@ -701,7 +701,7 @@ class _ImpactedSubstanceMixin(_ApiMixin, ABC):
     def with_legislations(self: Query_Builder, legislation_names: List[str]) -> Query_Builder:
         """Add a list or set of legislations to retrieve the impacted substances for.
 
-        The legislation records are referenced by legislation name.
+        Legislations are identified based on their ``Short title`` attribute value.
 
         Parameters
         ----------
@@ -722,7 +722,7 @@ class _ImpactedSubstanceMixin(_ApiMixin, ABC):
         --------
         >>> query = MaterialImpactedSubstancesQuery()
         >>> query = query.with_legislations(["California Proposition 65 List",
-        >>>                                  "REACH - The Candidate List"])
+        >>>                                  "EU REACH - The Candidate List"])
         <MaterialImpactedSubstances: 0 materials, batch size = 100, 2 legislations>
         """
 
@@ -872,7 +872,7 @@ class MaterialImpactedSubstancesQuery(_ImpactedSubstanceMixin, _MaterialQueryBui
     >>> query = (
     ...     MaterialImpactedSubstancesQuery()
     ...     .with_material_ids(['elastomer-butadienerubber', 'NBR-100'])
-    ...     .with_legislations(["REACH - The Candidate List"])
+    ...     .with_legislations(["EU REACH - The Candidate List"])
     ... )
     >>> cxn.run(query)
     <MaterialImpactedSubstancesQueryResult: 2 MaterialWithImpactedSubstances results>
@@ -978,7 +978,7 @@ class PartImpactedSubstancesQuery(_ImpactedSubstanceMixin, _PartQueryBuilder):
     >>> query = (
     ...     PartImpactedSubstancesQuery()
     ...     .with_part_numbers(['DRILL', 'FLRY34'])
-    ...     .with_legislations(["REACH - The Candidate List"])
+    ...     .with_legislations(["EU REACH - The Candidate List"])
     ... )
     >>> cxn.run(query)
     <PartImpactedSubstancesQueryResult: 2 PartWithImpactedSubstances results>
@@ -1087,7 +1087,7 @@ class SpecificationImpactedSubstancesQuery(_ImpactedSubstanceMixin, _Specificati
     >>> query = (
     ...     SpecificationImpactedSubstancesQuery()
     ...     .with_specification_ids(['MIL-A-8625', 'PSP101'])
-    ...     .with_legislations(["REACH - The Candidate List"])
+    ...     .with_legislations(["EU REACH - The Candidate List"])
     ... )
     >>> cxn.run(query)
     <SpecificationImpactedSubstancesQueryResult:
@@ -1641,7 +1641,7 @@ class BomImpactedSubstancesQuery(_ImpactedSubstanceMixin, _Bom1711QueryBuilder):
     >>> query = (
     ...     BomImpactedSubstancesQuery()
     ...     .with_bom("<PartsEco xmlns...")
-    ...     .with_legislations(["REACH - The Candidate List"])
+    ...     .with_legislations(["EU REACH - The Candidate List"])
     ... )
     >>> cxn.run(query)
     <BomImpactedSubstancesQueryResult: 1 Bom1711WithImpactedSubstances results>

--- a/src/ansys/grantami/bomanalytics/queries.py
+++ b/src/ansys/grantami/bomanalytics/queries.py
@@ -835,7 +835,7 @@ class MaterialComplianceQuery(_ComplianceMixin, _MaterialQueryBuilder):
 
     Examples
     --------
-    >>> cxn = Connection("http://localhost/mi_servicelayer").with_autologon().connect()
+    >>> cxn = Connection("http://my_mi_server/mi_servicelayer").with_autologon().connect()
     >>> indicator = WatchListIndicator(
     ...     name="Prop 65",
     ...     legislation_names=["California Proposition 65 List"]
@@ -868,7 +868,7 @@ class MaterialImpactedSubstancesQuery(_ImpactedSubstanceMixin, _MaterialQueryBui
 
     Examples
     --------
-    >>> cxn = Connection("http://localhost/mi_servicelayer").with_autologon().connect()
+    >>> cxn = Connection("http://my_mi_server/mi_servicelayer").with_autologon().connect()
     >>> query = (
     ...     MaterialImpactedSubstancesQuery()
     ...     .with_material_ids(['elastomer-butadienerubber', 'NBR-100'])
@@ -940,7 +940,7 @@ class PartComplianceQuery(_ComplianceMixin, _PartQueryBuilder):
 
     Examples
     --------
-    >>> cxn = Connection("http://localhost/mi_servicelayer").with_autologon().connect()
+    >>> cxn = Connection("http://my_mi_server/mi_servicelayer").with_autologon().connect()
     >>> indicator = WatchListIndicator(
     ...     name="Prop 65",
     ...     legislation_names=["California Proposition 65 List"]
@@ -974,7 +974,7 @@ class PartImpactedSubstancesQuery(_ImpactedSubstanceMixin, _PartQueryBuilder):
 
     Examples
     --------
-    >>> cxn = Connection("http://localhost/mi_servicelayer").with_autologon().connect()
+    >>> cxn = Connection("http://my_mi_server/mi_servicelayer").with_autologon().connect()
     >>> query = (
     ...     PartImpactedSubstancesQuery()
     ...     .with_part_numbers(['DRILL', 'FLRY34'])
@@ -1050,7 +1050,7 @@ class SpecificationComplianceQuery(_ComplianceMixin, _SpecificationQueryBuilder)
 
     Examples
     --------
-    >>> cxn = Connection("http://localhost/mi_servicelayer").with_autologon().connect()
+    >>> cxn = Connection("http://my_mi_server/mi_servicelayer").with_autologon().connect()
     >>> indicator = WatchListIndicator(
     ...     name="Prop 65",
     ...     legislation_names=["California Proposition 65 List"]
@@ -1083,7 +1083,7 @@ class SpecificationImpactedSubstancesQuery(_ImpactedSubstanceMixin, _Specificati
 
     Examples
     --------
-    >>> cxn = Connection("http://localhost/mi_servicelayer").with_autologon().connect()
+    >>> cxn = Connection("http://my_mi_server/mi_servicelayer").with_autologon().connect()
     >>> query = (
     ...     SpecificationImpactedSubstancesQuery()
     ...     .with_specification_ids(['MIL-A-8625', 'PSP101'])
@@ -1458,7 +1458,7 @@ class SubstanceComplianceQuery(_ComplianceMixin, _SubstanceQueryBuilder):
 
     Examples
     --------
-    >>> cxn = Connection("http://localhost/mi_servicelayer").with_autologon().connect()
+    >>> cxn = Connection("http://my_mi_server/mi_servicelayer").with_autologon().connect()
     >>> indicator = WatchListIndicator(
     ...     name="Prop 65",
     ...     legislation_names=["California Proposition 65 List"]
@@ -1602,7 +1602,7 @@ class BomComplianceQuery(_ComplianceMixin, _Bom1711QueryBuilder):
 
     Examples
     --------
-    >>> cxn = Connection("http://localhost/mi_servicelayer").with_autologon().connect()
+    >>> cxn = Connection("http://my_mi_server/mi_servicelayer").with_autologon().connect()
     >>> bom = "<PartsEco xmlns..."
     >>> indicator = WatchListIndicator(
     ...     name="Prop 65",
@@ -1636,7 +1636,7 @@ class BomImpactedSubstancesQuery(_ImpactedSubstanceMixin, _Bom1711QueryBuilder):
 
     Examples
     --------
-    >>> cxn = Connection("http://localhost/mi_servicelayer").with_autologon().connect()
+    >>> cxn = Connection("http://my_mi_server/mi_servicelayer").with_autologon().connect()
     >>> bom = "<PartsEco xmlns..."
     >>> query = (
     ...     BomImpactedSubstancesQuery()
@@ -1663,7 +1663,7 @@ class Yaml:
 
     Examples
     --------
-    >>> cxn = Connection("http://localhost/mi_servicelayer").with_autologon().connect()
+    >>> cxn = Connection("http://my_mi_server/mi_servicelayer").with_autologon().connect()
     >>> cxn.run(Yaml)
     openapi: 3.0.1
     info:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ from typing import List
 from ansys.grantami.bomanalytics import Connection
 from .common import CUSTOM_TABLES
 
-sl_url = os.getenv("TEST_SL_URL", "http://my_mi_server/mi_servicelayer")
+sl_url = os.getenv("TEST_SL_URL", "http://localhost/mi_servicelayer")
 read_username = os.getenv("TEST_USER")
 read_password = os.getenv("TEST_PASS")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ from typing import List
 from ansys.grantami.bomanalytics import Connection
 from .common import CUSTOM_TABLES
 
-sl_url = os.getenv("TEST_SL_URL", "http://localhost/mi_servicelayer")
+sl_url = os.getenv("TEST_SL_URL", "http://my_mi_server/mi_servicelayer")
 read_username = os.getenv("TEST_USER")
 read_password = os.getenv("TEST_PASS")
 


### PR DESCRIPTION
Closes #291 

After the move to use the latest version of the Restricted Substances database for CI, we now see the effects of changing from 'REACH' to 'EU REACH':

https://bomanalytics.grantami.docs.pyansys.com/version/dev/examples/0_Getting_started.html#View-query-results

![image](https://github.com/ansys/grantami-bomanalytics/assets/6451062/65310027-2c19-4586-92ef-d1a426a4f4b8)

The REACH legislation 'Short title' was changed from 'REACH - The Candidate List' to 'EU REACH - The Candidate List' to disambiguate from UK REACH, China REACH, Korea REACH, etc. As a result, the examples now return zero results.

This PR replaces 'REACH' with 'EU REACH' everywhere, which should reinstate the results. Check the built docs in the pre-merge checks to confirm.

I have also made a few other miscellaneous documentation changes while I was in the code:

* Fixed a missing space in a connection error string
* Replaced 'localhost' with 'my_server_name', to be consistent with jupyter notebook examples
* Added clarification as to what should be used for the legislation_name parameter. Note that we might change this to use the legislation id instead. At this point we could change the parameter name, causing people to adjust their scripts to avoid a silent failure.