### PR TITLE
CI - Set Python Version in Code Style Check

### DIFF
--- a/.github/workflows/local_checks.yml
+++ b/.github/workflows/local_checks.yml
@@ -15,10 +15,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python ${{ env.MAIN_PYTHON_VERSION }}
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: ${{ env.MAIN_PYTHON_VERSION }}
 
       - name: Install style requirements
         run: pip install 'tox<4' poetry --disable-pip-version-check


### PR DESCRIPTION
Warning in the logs about not setting the python version when installing python for the code style checks. This PR uses the `MAIN_PYTHON_VERSION` rather than the non-existent `matrix.python-version`.