### PR TITLE
347 - Use regex to replace server URL

### DIFF
--- a/.ipython/profile_default/startup/10-monkeypatch-connection.py
+++ b/.ipython/profile_default/startup/10-monkeypatch-connection.py
@@ -35,13 +35,15 @@ Connection.with_autologon = with_autologon
 server_url = "http://my_grantami_server/mi_servicelayer"
 
 BomAnalyticsClient._original_repr = BomAnalyticsClient.__repr__
-regex = re.compile(r'url="(.)+"')
+# \S is character class for 'not whitespace'
+regex = re.compile(r'url="(\S)+"')
 
 def __repr__(self: BomAnalyticsClient) -> str:
     result = self._original_repr()
-    sanitized_result, matach_count = regex.subn(f'url="{server_url}"', result)
-    if not matach_count:
-        raise ValueError("No match found for url in BomAnalyticsClient repr")
+    sanitized_result, match_count = regex.subn(f'url="{server_url}"', result)
+    if match_count != 1:
+        raise ValueError(f"Expected exactly one match for url in BomAnalyticsClient __repr__ output."
+                         f"Found {match_count} matches.")
     return sanitized_result
 
 

--- a/.ipython/profile_default/startup/10-monkeypatch-connection.py
+++ b/.ipython/profile_default/startup/10-monkeypatch-connection.py
@@ -1,4 +1,5 @@
 import os
+import re
 from ansys.grantami.bomanalytics import Connection
 from ansys.grantami.bomanalytics._connection import BomAnalyticsClient
 
@@ -30,12 +31,18 @@ Connection.with_credentials = with_credentials
 Connection.with_autologon = with_autologon
 
 
-# Monkey patch the Client object to report the url specified in the code, or the one below if not overridden
+# Monkey patch the Client object to report the url specified below
 server_url = "http://my_grantami_server/mi_servicelayer"
 
+BomAnalyticsClient._original_repr = BomAnalyticsClient.__repr__
+regex = re.compile(r'url="(.)+"')
 
 def __repr__(self: BomAnalyticsClient) -> str:
-    return f'<BomServicesClient: url="{server_url}", dbkey="{self._db_key}">'
+    result = self._original_repr()
+    sanitized_result, matach_count = regex.subn(f'url="{server_url}"', result)
+    if not matach_count:
+        raise ValueError("No match found for url in BomAnalyticsClient repr")
+    return sanitized_result
 
 
 BomAnalyticsClient.__repr__ = __repr__


### PR DESCRIPTION
Closes #347 

Use a regular expression to replace the URL in the BomAnalyticsClient repr. Raise a ValueError if no match is found.