### PR TITLE
CI - Report Coverage to Codacy

### DIFF
--- a/.github/workflows/local_checks.yml
+++ b/.github/workflows/local_checks.yml
@@ -60,6 +60,12 @@ jobs:
       - name: Test with tox (no integration tests)
         run: tox -- -m "not integration"
 
+      - name: Run codacy-coverage-reporter
+        uses: codacy/codacy-coverage-reporter-action@v1
+        with:
+          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+          coverage-reports: coverage.xml
+
       - name: Upload coverage report
         uses: codecov/codecov-action@v3
         with:


### PR DESCRIPTION
Codecov seems to be out of favor right now, codacy seems to be the place to be, so lets report there if we can.