### PR TITLE
Add metapackage instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,6 +54,13 @@ Install the ``ansys-grantami-bomanalytics`` package with this code:
 
    pip install ansys-grantami-bomanalytics
 
+To install a release compatible with a specific version of Granta MI, use the
+`PyGranta <https://grantami.docs.pyansys.com/>`_ meta-package with a requirement specifier:
+
+.. code::
+
+    pip install pygranta==2023.2.0
+
 Alternatively, clone and install this package with this code:
 
 .. code::

--- a/doc/source/getting_started/index.rst
+++ b/doc/source/getting_started/index.rst
@@ -18,6 +18,12 @@ this code:
 
     pip install ansys-grantami-bomanalytics
 
+To install a release compatible with a specific version of Granta MI, use the
+`PyGranta <https://grantami.docs.pyansys.com/>`_ meta-package with a requirement specifier:
+
+.. code::
+
+    pip install pygranta==2023.2.0
 
 Alternatively, to install the latest from `ansys-grantami-bomanalytics GitHub <https://github.com/ansys/grantami-bomanalytics>`_,
 use this code:


### PR DESCRIPTION
Add instructions for installing this package via the pygranta metapackage.

There isn't as much reuse in this repo as in recordlists, and so the change was required in two places. I have created #389 to see if we can address this in future.