### PR TITLE
Docs: update product help links

### DIFF
--- a/doc/source/api/query_type_differences.rst
+++ b/doc/source/api/query_type_differences.rst
@@ -40,7 +40,7 @@ included in the analysis and returned in the response.
 BoM-based queries
 ~~~~~~~~~~~~~~~~~
 In a BoM-based query, only child specifications are included in the analysis and returned in the
-response. Considering a :class:`~.BoMComplianceQuery` containing the root part
+response. Considering a :class:`~.BomComplianceQuery` containing the root part
 in structure described above, only the child specifications are included in the analysis and
 returned in the response. The child part and material are *not* included unless they are explicitly
 added to the BoM.

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -101,7 +101,7 @@ numpydoc_validation_exclude = {
 
 extlinks = {
     'MI_docs': (
-        'https://miniature-fortnight-dc09be55.pages.github.io/granta/v241/en/RS_and_Sustainability/%s',
+        'https://ansyshelp.ansys.com/account/secured?returnurl=/Views/Secured/Granta/v241/en/RS_and_Sustainability/%s',
         None
     )
 }


### PR DESCRIPTION
Update the root url for external links to the product help site.
I've checked all the links with the new root and they all are functioning.