### PR TITLE
Docs: CNAME update

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -157,7 +157,7 @@ copybutton_prompt_is_regexp = True
 
 
 # -- Options for HTML output -------------------------------------------------
-cname = os.getenv("DOCUMENTATION_CNAME", "animated-broccoli-k6emqn7.pages.github.io")
+cname = os.getenv("DOCUMENTATION_CNAME", "bomanalytics.grantami.docs.pyansys.com")
 """The canonical name of the webpage hosting the documentation."""
 html_theme = "ansys_sphinx_theme"
 html_favicon = ansys_favicon
@@ -173,7 +173,7 @@ html_theme_options = {
         "json_url": f"https://{cname}/versions.json",
         "version_match": get_version_match(__version__),
     },
-    "check_switcher": False
+    "check_switcher": True
 }
 
 # -- Options for HTMLHelp output ---------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.core.masonry.api"
 [tool.poetry]
 name = "ansys-grantami-bomanalytics"
 description = "Perform compliance analysis on materials data stored in Granta MI."
-version = "1.2.0"
+version = "2.0.0dev0"
 license = "MIT"
 authors = ["ANSYS, Inc. <pyansys.core@ansys.com>"]
 maintainers = ["ANSYS, Inc. <pyansys.core@ansys.com>"]


### PR DESCRIPTION
Update the default CNAME in the Sphinx config.
I think long term we should consider removing this and disabling the version switcher if the env variable is not set. On CI we'd build with the correct CNAME passed as env. Locally we'd build docs without a version switcher.

Also updated the version so that the dev docs have a more adequate version on the homepage.