### PR TITLE
Add labeler workflow

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,6 +1,6 @@
 documentation:
 - changed-files:
-  - any-glob-to-any-file: ['doc/source/**/*']
+  - any-glob-to-any-file: ['doc/source/**/*', 'examples/**/*']
 maintenance:
 - changed-files:
   - any-glob-to-any-file: ['.github/**/*', '.flake8', 'pyproject.toml']

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,9 @@
+documentation:
+- changed-files:
+  - any-glob-to-any-file: ['doc/source/**/*']
+maintenance:
+- changed-files:
+  - any-glob-to-any-file: ['.github/**/*', '.flake8', 'pyproject.toml']
+dependencies:
+- changed-files:
+  - any-glob-to-any-file: ['poetry.lock']

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -12,15 +12,6 @@ concurrency:
 
 jobs:
 
-  label-syncer:
-    name: Syncer
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: micnncim/action-label-syncer@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   labeler:
     name: Set labels
     needs: [label-syncer]

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,0 +1,84 @@
+name: Labeler
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+    paths:
+      - '../labels.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+
+  label-syncer:
+    name: Syncer
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: micnncim/action-label-syncer@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  labeler:
+    name: Set labels
+    needs: [label-syncer]
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+
+    # Label based on modified files
+    - name: Label based on changed files
+      uses: actions/labeler@v5
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+    # Label based on branch name
+    - uses: actions-ecosystem/action-add-labels@v1
+      if: |
+        startsWith(github.event.pull_request.head.ref, 'doc') ||
+        startsWith(github.event.pull_request.head.ref, 'docs')
+      with:
+        labels: documentation
+
+    - uses: actions-ecosystem/action-add-labels@v1
+      if: |
+        startsWith(github.event.pull_request.head.ref, 'maint') ||
+        startsWith(github.event.pull_request.head.ref, 'no-ci') ||
+        startsWith(github.event.pull_request.head.ref, 'ci')
+      with:
+        labels: maintenance
+
+    - uses: actions-ecosystem/action-add-labels@v1
+      if: startsWith(github.event.pull_request.head.ref, 'feat')
+      with:
+        labels: |
+          enhancement
+
+    - uses: actions-ecosystem/action-add-labels@v1
+      if: |
+        startsWith(github.event.pull_request.head.ref, 'fix') ||
+        startsWith(github.event.pull_request.head.ref, 'patch')
+      with:
+        labels: bug
+
+  commenter:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Suggest to add labels
+      uses: peter-evans/create-or-update-comment@v3
+      # Execute only when no labels have been applied to the pull request
+      if: toJSON(github.event.pull_request.labels.*.name) == '{}'
+      with:
+        issue-number: ${{ github.event.pull_request.number }}
+        body: |
+          Please add one of the following labels to add this contribution to the Release Notes :point_down:
+          - [bug](https://github.com/ansys/grantami-recordlists/pulls?q=label%3Abug+)
+          - [documentation](https://github.com/ansys/grantami-recordlists/pulls?q=label%3Adocumentation+)
+          - [enhancement](https://github.com/ansys/grantami-recordlists/pulls?q=label%3Aenhancement+)
+          - [good first issue](https://github.com/ansys/grantami-recordlists/pulls?q=label%3Agood+first+issue)
+          - [maintenance](https://github.com/ansys/grantami-recordlists/pulls?q=label%3Amaintenance+)
+          - [release](https://github.com/ansys/grantami-recordlists/pulls?q=label%3Arelease+)

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -14,7 +14,6 @@ jobs:
 
   labeler:
     name: Set labels
-    needs: [label-syncer]
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
Add a workflow to automatically label PRs. There will be a follow up PR to use the labels to organize automatically generated release notes.

The configuration is identical to recordlists, which is the default that comes with ansys repo templates.
Labels are applied based on two things:
- location of the modified files
- name of the branch (`maint/*` -> `maintenance`, etc)