### PR TITLE
Add missing versionadded directives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 * [Issue #466](https://github.com/ansys/grantami-bomanalytics/issues/466),
   [Pull request #467](https://github.com/ansys/grantami-bomanalytics/pull/467): Tidy up bulleted lists in API documentation.
+* [Issue #464](https://github.com/ansys/grantami-bomanalytics/issues/466),
+  [Pull request #467](https://github.com/ansys/grantami-bomanalytics/pull/467): Add `versionadded` directives to API documentation.
 
 ### Contributors
 

--- a/doc/source/api/bom_builder/api.rst
+++ b/doc/source/api/bom_builder/api.rst
@@ -3,6 +3,8 @@
 BoM object model
 ================
 
+.. versionadded:: 2.0
+
 .. note::
    The models documented below are Python bindings for the Ansys Granta MI 23/01 XML schema.
    Not all elements are required to define a valid BoM for analysis, and not all elements have an impact on all types of analysis.

--- a/doc/source/api/bom_builder/api.rst
+++ b/doc/source/api/bom_builder/api.rst
@@ -3,8 +3,6 @@
 BoM object model
 ================
 
-.. versionadded:: 2.0
-
 .. note::
    The models documented below are Python bindings for the Ansys Granta MI 23/01 XML schema.
    Not all elements are required to define a valid BoM for analysis, and not all elements have an impact on all types of analysis.
@@ -20,6 +18,7 @@ BoM object model
    elements. It is still possible to deserialize an XML BoM that uses these elements, but these elements cannot be
    converted to Python objects.
 
+.. versionadded:: 2.0
 
 .. _ref_grantami_bomanalytics_api_billofmaterials:
 .. autoclass:: ansys.grantami.bomanalytics.bom_types._bom_types.BillOfMaterials

--- a/doc/source/api/bom_builder/index.rst
+++ b/doc/source/api/bom_builder/index.rst
@@ -3,6 +3,8 @@
 BoM helpers
 ==============
 
+.. versionadded:: 2.0
+
 This section provides an introduction to the BoM Helpers. These represent a BoM (bill of materials) in Ansys Granta
 MI 2301 XML BoM format, and support reading and writing these files.
 

--- a/doc/source/api/bom_builder/index.rst
+++ b/doc/source/api/bom_builder/index.rst
@@ -3,8 +3,6 @@
 BoM helpers
 ==============
 
-.. versionadded:: 2.0
-
 This section provides an introduction to the BoM Helpers. These represent a BoM (bill of materials) in Ansys Granta
 MI 2301 XML BoM format, and support reading and writing these files.
 
@@ -17,6 +15,8 @@ the correct formation of these reference objects, depending on how you need to r
 Serialization and Deserialization of BoM objects can be performed using the :class:`~ansys.grantami.bomanalytics._bom_helper.BoMHandler`.
 This exposes methods to read a BoM from a string or a file, and to write to a string or a file. The resulting BoM can be
 passed to either a Sustainability or a Compliance query.
+
+.. versionadded:: 2.0
 
 .. toctree::
    :maxdepth: 2

--- a/doc/source/api/sustainability/index.rst
+++ b/doc/source/api/sustainability/index.rst
@@ -3,8 +3,6 @@
 Sustainability API
 ==================
 
-.. versionadded:: 2.0
-
 This section provides an overview of the API for sustainability. The
 :ref:`ref_grantami_bomanalytics_api_sustainability_bom` and
 :ref:`ref_grantami_bomanalytics_api_sustainability_summary_bom` queries can be used to determine the
@@ -22,6 +20,8 @@ section of the online documentation.
   Substances feature included in your license. A
   :class:`~ansys.grantami.bomanalytics.LicensingException` will be raised if the feature is not
   available.
+
+.. versionadded:: 2.0
 
 .. toctree::
    :maxdepth: 3

--- a/doc/source/api/sustainability/index.rst
+++ b/doc/source/api/sustainability/index.rst
@@ -3,6 +3,8 @@
 Sustainability API
 ==================
 
+.. versionadded:: 2.0
+
 This section provides an overview of the API for sustainability. The
 :ref:`ref_grantami_bomanalytics_api_sustainability_bom` and
 :ref:`ref_grantami_bomanalytics_api_sustainability_summary_bom` queries can be used to determine the

--- a/src/ansys/grantami/bomanalytics/_bom_helper.py
+++ b/src/ansys/grantami/bomanalytics/_bom_helper.py
@@ -14,6 +14,8 @@ if TYPE_CHECKING:
 class BoMHandler:
     """
     Handler for XML formatted BoMs, supports reading from files and strings, and serializing to string format.
+
+    .. versionadded:: 2.0
     """
 
     _schema_path: Path = bom_schema_2301

--- a/src/ansys/grantami/bomanalytics/_connection.py
+++ b/src/ansys/grantami/bomanalytics/_connection.py
@@ -330,15 +330,15 @@ class BomAnalyticsClient(ApiClient):
             Name of the table that implements the ``ProcessUniverse`` schema. The default
             is ``None``, in which case  ``ProcessUniverse`` is used.
         location_table_name : str, optional
-            .. versionadded:: 2.0
-
             Name of the table that implements the ``Location`` schema. The default
             is ``None``, in which case  ``Location`` is used.
-        transport_table_name : str, optional
-            .. versionadded:: 2.0
 
+            .. versionadded:: 2.0
+        transport_table_name : str, optional
             Name of the table that implements the ``Transport`` schema. The default
             is ``None``, in which case  ``Transport`` is used.
+
+            .. versionadded:: 2.0
 
         Notes
         -----

--- a/src/ansys/grantami/bomanalytics/_connection.py
+++ b/src/ansys/grantami/bomanalytics/_connection.py
@@ -264,6 +264,8 @@ class BomAnalyticsClient(ApiClient):
         Supported with Restricted Substances Reports 2023 R2 and newer, with older reports this parameter has
         no effect, all specification-to-specification links will be followed.
 
+        .. versionadded:: 1.2
+
         .. note::
             This limit applies to each branch of the BoM individually. This is not a global limit on the number of
             specification-to-specification links that will be traversed across the entire BoM, instead it is a limit on
@@ -328,9 +330,13 @@ class BomAnalyticsClient(ApiClient):
             Name of the table that implements the ``ProcessUniverse`` schema. The default
             is ``None``, in which case  ``ProcessUniverse`` is used.
         location_table_name : str, optional
+            .. versionadded:: 2.0
+
             Name of the table that implements the ``Location`` schema. The default
             is ``None``, in which case  ``Location`` is used.
         transport_table_name : str, optional
+            .. versionadded:: 2.0
+
             Name of the table that implements the ``Transport`` schema. The default
             is ``None``, in which case  ``Transport`` is used.
 

--- a/src/ansys/grantami/bomanalytics/_item_definitions.py
+++ b/src/ansys/grantami/bomanalytics/_item_definitions.py
@@ -385,8 +385,7 @@ class CoatingReferenceWithIdentifier(IdentifierMixin, CoatingReference):
 class ProcessReference(RecordReference):
     # Because of ProcessSummaryResult, this is publicly documented.
     # Extends RecordReference without changes, to re-define the class name, because it appears in the repr.
-    """
-    Represents a reference to a Process record.
+    """Represents a reference to a Process record.
 
     .. versionadded:: 2.0
     """
@@ -397,8 +396,7 @@ class ProcessReferenceWithIdentifiers(CommonIdentifiersMixin, ProcessReference):
 
 
 class TransportReference(RecordReference):
-    """
-    Represents a reference to a Transport record.
+    """Represents a reference to a Transport record.
 
     .. versionadded:: 2.0
     """

--- a/src/ansys/grantami/bomanalytics/_item_definitions.py
+++ b/src/ansys/grantami/bomanalytics/_item_definitions.py
@@ -385,9 +385,10 @@ class CoatingReferenceWithIdentifier(IdentifierMixin, CoatingReference):
 class ProcessReference(RecordReference):
     # Because of ProcessSummaryResult, this is publicly documented.
     # Extends RecordReference without changes, to re-define the class name, because it appears in the repr.
-    """.. versionadded:: 2.0
-
+    """
     Represents a reference to a Process record.
+
+    .. versionadded:: 2.0
     """
 
 
@@ -396,9 +397,10 @@ class ProcessReferenceWithIdentifiers(CommonIdentifiersMixin, ProcessReference):
 
 
 class TransportReference(RecordReference):
-    """.. versionadded:: 2.0
-
+    """
     Represents a reference to a Transport record.
+
+    .. versionadded:: 2.0
     """
 
     # Extends RecordReference without changes, to re-define the class name, because it appears in the repr

--- a/src/ansys/grantami/bomanalytics/_item_definitions.py
+++ b/src/ansys/grantami/bomanalytics/_item_definitions.py
@@ -385,7 +385,10 @@ class CoatingReferenceWithIdentifier(IdentifierMixin, CoatingReference):
 class ProcessReference(RecordReference):
     # Because of ProcessSummaryResult, this is publicly documented.
     # Extends RecordReference without changes, to re-define the class name, because it appears in the repr.
-    """Represents a reference to a Process record."""
+    """.. versionadded:: 2.0
+
+    Represents a reference to a Process record.
+    """
 
 
 class ProcessReferenceWithIdentifiers(CommonIdentifiersMixin, ProcessReference):
@@ -393,7 +396,10 @@ class ProcessReferenceWithIdentifiers(CommonIdentifiersMixin, ProcessReference):
 
 
 class TransportReference(RecordReference):
-    """Represents a reference to a Transport record."""
+    """.. versionadded:: 2.0
+
+    Represents a reference to a Transport record.
+    """
 
     # Extends RecordReference without changes, to re-define the class name, because it appears in the repr
 

--- a/src/ansys/grantami/bomanalytics/_item_results.py
+++ b/src/ansys/grantami/bomanalytics/_item_results.py
@@ -1252,8 +1252,7 @@ class SubstanceWithComplianceResult(ComplianceResultMixin, SubstanceReferenceWit
 
     @property
     def percentage_amount(self) -> Optional[float]:
-        """
-        Percentage amount of this substance in the parent item.
+        """Percentage amount of this substance in the parent item.
 
         .. versionadded:: 2.1
         """
@@ -1328,8 +1327,7 @@ class CoatingWithComplianceResult(
 
 
 class ValueWithUnit:
-    """
-    Describes a value obtained from the API.
+    """Describes a value obtained from the API.
 
     .. versionadded:: 2.0
     """
@@ -1621,8 +1619,7 @@ class MaterialWithSustainabilityResult(
     MassResultMixin,
     MaterialReferenceWithIdentifiers,
 ):
-    """
-    Describes an individual material included as part of a sustainability query result.
+    """Describes an individual material included as part of a sustainability query result.
     This object includes three categories of attributes:
 
     * The reference to the material in Granta MI
@@ -1641,8 +1638,7 @@ class PartWithSustainabilityResult(
     MassResultMixin,
     PartReferenceWithIdentifiers,
 ):
-    """
-    Describes an individual part included as part of a sustainability query result.
+    """Describes an individual part included as part of a sustainability query result.
     This object includes three categories of attributes:
 
     * The reference to the part in Granta MI (if the part references a record)
@@ -1657,8 +1653,7 @@ class ProcessWithSustainabilityResult(
     SustainabilityResultMixin,
     ProcessReferenceWithIdentifiers,
 ):
-    """
-    Describes a process included as part of a sustainability query result.
+    """Describes a process included as part of a sustainability query result.
     This object includes two categories of attributes:
 
     * The reference to the process record in Granta MI
@@ -1672,8 +1667,7 @@ class TransportWithSustainabilityResult(
     SustainabilityResultMixin,
     TransportReferenceWithIdentifier,
 ):
-    """
-    Describes a transport stage included as part of a sustainability query result.
+    """Describes a transport stage included as part of a sustainability query result.
     This object includes two categories of attributes:
 
     * The reference to the transport record in Granta MI
@@ -2021,8 +2015,7 @@ class ProcessSummaryResult(SustainabilitySummaryBase):
 
 
 class Licensing:
-    """
-    Granta MI BomAnalytics Services licensing information.
+    """Granta MI BomAnalytics Services licensing information.
 
     .. versionadded:: 2.0
     """

--- a/src/ansys/grantami/bomanalytics/_item_results.py
+++ b/src/ansys/grantami/bomanalytics/_item_results.py
@@ -1252,7 +1252,10 @@ class SubstanceWithComplianceResult(ComplianceResultMixin, SubstanceReferenceWit
 
     @property
     def percentage_amount(self) -> Optional[float]:
-        """Percentage amount of this substance in the parent item."""
+        """
+        .. versionadded:: 2.1
+
+        Percentage amount of this substance in the parent item."""
         return self._percentage_amount
 
 
@@ -1324,7 +1327,10 @@ class CoatingWithComplianceResult(
 
 
 class ValueWithUnit:
-    """Describes a value obtained from the API."""
+    """.. versionadded:: 2.0
+
+    Describes a value obtained from the API.
+    """
 
     def __init__(
         self,
@@ -1613,7 +1619,9 @@ class MaterialWithSustainabilityResult(
     MassResultMixin,
     MaterialReferenceWithIdentifiers,
 ):
-    """Describes an individual material included as part of a sustainability query result.
+    """.. versionadded:: 2.0
+
+    Describes an individual material included as part of a sustainability query result.
     This object includes three categories of attributes:
 
     * The reference to the material in Granta MI
@@ -1630,7 +1638,9 @@ class PartWithSustainabilityResult(
     MassResultMixin,
     PartReferenceWithIdentifiers,
 ):
-    """Describes an individual part included as part of a sustainability query result.
+    """.. versionadded:: 2.0
+
+    Describes an individual part included as part of a sustainability query result.
     This object includes three categories of attributes:
 
     * The reference to the part in Granta MI (if the part references a record)
@@ -1643,7 +1653,9 @@ class ProcessWithSustainabilityResult(
     SustainabilityResultMixin,
     ProcessReferenceWithIdentifiers,
 ):
-    """Describes a process included as part of a sustainability query result.
+    """.. versionadded:: 2.0
+
+    Describes a process included as part of a sustainability query result.
     This object includes two categories of attributes:
 
     * The reference to the process record in Granta MI
@@ -1655,7 +1667,9 @@ class TransportWithSustainabilityResult(
     SustainabilityResultMixin,
     TransportReferenceWithIdentifier,
 ):
-    """Describes a transport stage included as part of a sustainability query result.
+    """.. versionadded:: 2.0
+
+    Describes a transport stage included as part of a sustainability query result.
     This object includes two categories of attributes:
 
     * The reference to the transport record in Granta MI
@@ -1740,6 +1754,8 @@ class SustainabilitySummaryBase:
 
 class SustainabilityPhaseSummaryResult(SustainabilitySummaryBase):
     """
+    .. versionadded:: 2.0
+
     High-level sustainability summary for a phase.
 
     Phases currently include:
@@ -1747,7 +1763,6 @@ class SustainabilityPhaseSummaryResult(SustainabilitySummaryBase):
     * ``Material``
     * ``Processes``
     * ``Transport``
-
     """
 
     def __init__(
@@ -1772,6 +1787,8 @@ class SustainabilityPhaseSummaryResult(SustainabilitySummaryBase):
 
 class TransportSummaryResult(SustainabilitySummaryBase):
     """
+    .. versionadded:: 2.0
+
     Sustainability summary for a transport stage.
     """
 
@@ -1813,6 +1830,8 @@ class TransportSummaryResult(SustainabilitySummaryBase):
 
 class ContributingComponentResult:
     """
+    .. versionadded:: 2.0
+
     Describes a Part item of the BoM.
 
     Listed as :attr:`~.MaterialSummaryResult.contributors` of a :class:`~.MaterialSummaryResult`.
@@ -1867,6 +1886,8 @@ class ContributingComponentResult:
 
 class MaterialSummaryResult(SustainabilitySummaryBase):
     """
+    .. versionadded:: 2.0
+
     Aggregated sustainability summary for a material.
 
     Describes the environmental footprint of a unique material, accounting for all occurrences of the material in BoM.
@@ -1928,6 +1949,8 @@ class MaterialSummaryResult(SustainabilitySummaryBase):
 
 class ProcessSummaryResult(SustainabilitySummaryBase):
     """
+    .. versionadded:: 2.0
+
     Aggregated sustainability summary for a process.
 
     For primary and secondary processes, this corresponds to a unique process/material combination. For joining and
@@ -1992,7 +2015,10 @@ class ProcessSummaryResult(SustainabilitySummaryBase):
 
 
 class Licensing:
-    """Granta MI BomAnalytics Services licensing information."""
+    """.. versionadded:: 2.0
+
+    Granta MI BomAnalytics Services licensing information.
+    """
 
     def __init__(self, restricted_substances: bool, sustainability: bool):
         self._restricted_substances: bool = restricted_substances

--- a/src/ansys/grantami/bomanalytics/_item_results.py
+++ b/src/ansys/grantami/bomanalytics/_item_results.py
@@ -1253,9 +1253,10 @@ class SubstanceWithComplianceResult(ComplianceResultMixin, SubstanceReferenceWit
     @property
     def percentage_amount(self) -> Optional[float]:
         """
-        .. versionadded:: 2.1
+        Percentage amount of this substance in the parent item.
 
-        Percentage amount of this substance in the parent item."""
+        .. versionadded:: 2.1
+        """
         return self._percentage_amount
 
 
@@ -1327,9 +1328,10 @@ class CoatingWithComplianceResult(
 
 
 class ValueWithUnit:
-    """.. versionadded:: 2.0
-
+    """
     Describes a value obtained from the API.
+
+    .. versionadded:: 2.0
     """
 
     def __init__(
@@ -1619,14 +1621,15 @@ class MaterialWithSustainabilityResult(
     MassResultMixin,
     MaterialReferenceWithIdentifiers,
 ):
-    """.. versionadded:: 2.0
-
+    """
     Describes an individual material included as part of a sustainability query result.
     This object includes three categories of attributes:
 
     * The reference to the material in Granta MI
     * The sustainability information for this material
     * Any process objects that are a child of this material object
+
+    .. versionadded:: 2.0
     """
 
 
@@ -1638,14 +1641,15 @@ class PartWithSustainabilityResult(
     MassResultMixin,
     PartReferenceWithIdentifiers,
 ):
-    """.. versionadded:: 2.0
-
+    """
     Describes an individual part included as part of a sustainability query result.
     This object includes three categories of attributes:
 
     * The reference to the part in Granta MI (if the part references a record)
     * The sustainability information for this part
     * Any part, material, or process objects which are a child of this part object
+
+    .. versionadded:: 2.0
     """
 
 
@@ -1653,13 +1657,14 @@ class ProcessWithSustainabilityResult(
     SustainabilityResultMixin,
     ProcessReferenceWithIdentifiers,
 ):
-    """.. versionadded:: 2.0
-
+    """
     Describes a process included as part of a sustainability query result.
     This object includes two categories of attributes:
 
     * The reference to the process record in Granta MI
     * The sustainability information for this process
+
+    .. versionadded:: 2.0
     """
 
 
@@ -1667,13 +1672,14 @@ class TransportWithSustainabilityResult(
     SustainabilityResultMixin,
     TransportReferenceWithIdentifier,
 ):
-    """.. versionadded:: 2.0
-
+    """
     Describes a transport stage included as part of a sustainability query result.
     This object includes two categories of attributes:
 
     * The reference to the transport record in Granta MI
     * The sustainability information for this transport stage
+
+    .. versionadded:: 2.0
     """
 
     def __init__(
@@ -1754,8 +1760,6 @@ class SustainabilitySummaryBase:
 
 class SustainabilityPhaseSummaryResult(SustainabilitySummaryBase):
     """
-    .. versionadded:: 2.0
-
     High-level sustainability summary for a phase.
 
     Phases currently include:
@@ -1763,6 +1767,8 @@ class SustainabilityPhaseSummaryResult(SustainabilitySummaryBase):
     * ``Material``
     * ``Processes``
     * ``Transport``
+
+    .. versionadded:: 2.0
     """
 
     def __init__(
@@ -1787,9 +1793,9 @@ class SustainabilityPhaseSummaryResult(SustainabilitySummaryBase):
 
 class TransportSummaryResult(SustainabilitySummaryBase):
     """
-    .. versionadded:: 2.0
-
     Sustainability summary for a transport stage.
+
+    .. versionadded:: 2.0
     """
 
     def __init__(
@@ -1830,11 +1836,11 @@ class TransportSummaryResult(SustainabilitySummaryBase):
 
 class ContributingComponentResult:
     """
-    .. versionadded:: 2.0
-
     Describes a Part item of the BoM.
 
     Listed as :attr:`~.MaterialSummaryResult.contributors` of a :class:`~.MaterialSummaryResult`.
+
+    .. versionadded:: 2.0
     """
 
     def __init__(
@@ -1886,11 +1892,11 @@ class ContributingComponentResult:
 
 class MaterialSummaryResult(SustainabilitySummaryBase):
     """
-    .. versionadded:: 2.0
-
     Aggregated sustainability summary for a material.
 
     Describes the environmental footprint of a unique material, accounting for all occurrences of the material in BoM.
+
+    .. versionadded:: 2.0
     """
 
     def __init__(
@@ -1949,8 +1955,6 @@ class MaterialSummaryResult(SustainabilitySummaryBase):
 
 class ProcessSummaryResult(SustainabilitySummaryBase):
     """
-    .. versionadded:: 2.0
-
     Aggregated sustainability summary for a process.
 
     For primary and secondary processes, this corresponds to a unique process/material combination. For joining and
@@ -1959,6 +1963,8 @@ class ProcessSummaryResult(SustainabilitySummaryBase):
 
     Describes the environmental footprint of a process, accounting for all occurrences of the process-material pair
     found in the BoM.
+
+    .. versionadded:: 2.0
     """
 
     def __init__(
@@ -2015,9 +2021,10 @@ class ProcessSummaryResult(SustainabilitySummaryBase):
 
 
 class Licensing:
-    """.. versionadded:: 2.0
-
+    """
     Granta MI BomAnalytics Services licensing information.
+
+    .. versionadded:: 2.0
     """
 
     def __init__(self, restricted_substances: bool, sustainability: bool):

--- a/src/ansys/grantami/bomanalytics/_query_results.py
+++ b/src/ansys/grantami/bomanalytics/_query_results.py
@@ -737,9 +737,10 @@ class BomComplianceQueryResult(ComplianceBaseClass):
 
 @QueryResultFactory.register(models.GetSustainabilityForBom2301Response)
 class BomSustainabilityQueryResult(ResultBaseClass):
-    """.. versionadded:: 2.0
-
+    """
     Describes the result of running a :class:`~ansys.grantami.bomanalytics.queries.BomSustainabilityQuery`.
+
+    .. versionadded:: 2.0
     """
 
     def __init__(
@@ -791,9 +792,10 @@ class BomSustainabilityQueryResult(ResultBaseClass):
 
 @QueryResultFactory.register(models.GetSustainabilitySummaryForBom2301Response)
 class BomSustainabilitySummaryQueryResult(ResultBaseClass):
-    """.. versionadded:: 2.0
-
+    """
     Describes the result of running a :class:`~ansys.grantami.bomanalytics.queries.BomSustainabilitySummaryQuery`.
+
+    .. versionadded:: 2.0
     """
 
     def __init__(

--- a/src/ansys/grantami/bomanalytics/_query_results.py
+++ b/src/ansys/grantami/bomanalytics/_query_results.py
@@ -737,7 +737,10 @@ class BomComplianceQueryResult(ComplianceBaseClass):
 
 @QueryResultFactory.register(models.GetSustainabilityForBom2301Response)
 class BomSustainabilityQueryResult(ResultBaseClass):
-    """Describes the result of running a :class:`~ansys.grantami.bomanalytics.queries.BomSustainabilityQuery`."""
+    """.. versionadded:: 2.0
+
+    Describes the result of running a :class:`~ansys.grantami.bomanalytics.queries.BomSustainabilityQuery`.
+    """
 
     def __init__(
         self,
@@ -788,7 +791,10 @@ class BomSustainabilityQueryResult(ResultBaseClass):
 
 @QueryResultFactory.register(models.GetSustainabilitySummaryForBom2301Response)
 class BomSustainabilitySummaryQueryResult(ResultBaseClass):
-    """Describes the result of running a :class:`~ansys.grantami.bomanalytics.queries.BomSustainabilitySummaryQuery`."""
+    """.. versionadded:: 2.0
+
+    Describes the result of running a :class:`~ansys.grantami.bomanalytics.queries.BomSustainabilitySummaryQuery`.
+    """
 
     def __init__(
         self,

--- a/src/ansys/grantami/bomanalytics/_query_results.py
+++ b/src/ansys/grantami/bomanalytics/_query_results.py
@@ -737,8 +737,7 @@ class BomComplianceQueryResult(ComplianceBaseClass):
 
 @QueryResultFactory.register(models.GetSustainabilityForBom2301Response)
 class BomSustainabilityQueryResult(ResultBaseClass):
-    """
-    Describes the result of running a :class:`~ansys.grantami.bomanalytics.queries.BomSustainabilityQuery`.
+    """Describes the result of running a :class:`~ansys.grantami.bomanalytics.queries.BomSustainabilityQuery`.
 
     .. versionadded:: 2.0
     """
@@ -792,8 +791,7 @@ class BomSustainabilityQueryResult(ResultBaseClass):
 
 @QueryResultFactory.register(models.GetSustainabilitySummaryForBom2301Response)
 class BomSustainabilitySummaryQueryResult(ResultBaseClass):
-    """
-    Describes the result of running a :class:`~ansys.grantami.bomanalytics.queries.BomSustainabilitySummaryQuery`.
+    """Describes the result of running a :class:`~ansys.grantami.bomanalytics.queries.BomSustainabilitySummaryQuery`.
 
     .. versionadded:: 2.0
     """

--- a/src/ansys/grantami/bomanalytics/bom_types/_builders.py
+++ b/src/ansys/grantami/bomanalytics/bom_types/_builders.py
@@ -88,6 +88,8 @@ class _FinalAttributeReferenceBuilder:
 
 class AttributeReferenceBuilder:
     """
+    .. versionadded:: 2.0
+
     Create a MI Attribute Reference with a valid combination of properties.
 
     Parameters
@@ -156,6 +158,8 @@ class AttributeReferenceBuilder:
 
 class RecordReferenceBuilder:
     """
+    .. versionadded:: 2.0
+
     Create a MIRecordReference with a valid combination of properties.
 
     Parameters

--- a/src/ansys/grantami/bomanalytics/bom_types/_builders.py
+++ b/src/ansys/grantami/bomanalytics/bom_types/_builders.py
@@ -88,9 +88,9 @@ class _FinalAttributeReferenceBuilder:
 
 class AttributeReferenceBuilder:
     """
-    .. versionadded:: 2.0
-
     Create a MI Attribute Reference with a valid combination of properties.
+
+    .. versionadded:: 2.0
 
     Parameters
     ----------
@@ -158,9 +158,9 @@ class AttributeReferenceBuilder:
 
 class RecordReferenceBuilder:
     """
-    .. versionadded:: 2.0
-
     Create a MIRecordReference with a valid combination of properties.
+
+    .. versionadded:: 2.0
 
     Parameters
     ----------

--- a/src/ansys/grantami/bomanalytics/indicators.py
+++ b/src/ansys/grantami/bomanalytics/indicators.py
@@ -373,10 +373,10 @@ class RoHSIndicator(_Indicator):
     name : str
         Name of the indicator that is to identify the indicator in the query result.
     legislation_ids : list[str]
-        .. versionadded:: 2.0
-
         Legislations against which compliance will be determined. Legislations are identified based
         on their ``Legislation ID`` attribute value.
+
+        .. versionadded:: 2.0
 
         .. important::
            This argument replaces ``legislation_names``, which has been removed in version **2.0**.
@@ -471,10 +471,10 @@ class WatchListIndicator(_Indicator):
     name : str
         Name of the indicator that is used to identify the indicator in the query result.
     legislation_ids : list[str]
-        .. versionadded:: 2.0
-
         Legislations against which compliance will be determined. Legislations are identified based
         on their ``Legislation ID`` attribute value.
+
+        .. versionadded:: 2.0
 
         .. important::
            This argument replaces ``legislation_names``, which has been removed in version **2.0**.

--- a/src/ansys/grantami/bomanalytics/queries.py
+++ b/src/ansys/grantami/bomanalytics/queries.py
@@ -1827,8 +1827,7 @@ class _SustainabilityMixin(_ApiMixin):
 
 
 class BomSustainabilityQuery(_SustainabilityMixin, _BomQueryBuilder):
-    """
-    Evaluates sustainability impact for a BoM in the Ansys Granta 2301 XML BoM format, and returns metrics for each
+    """Evaluates sustainability impact for a BoM in the Ansys Granta 2301 XML BoM format, and returns metrics for each
     item in the BoM.
 
     The methods used to configure units and add the BoM to this query return the query itself so that they can be

--- a/src/ansys/grantami/bomanalytics/queries.py
+++ b/src/ansys/grantami/bomanalytics/queries.py
@@ -1827,8 +1827,7 @@ class _SustainabilityMixin(_ApiMixin):
 
 
 class BomSustainabilityQuery(_SustainabilityMixin, _BomQueryBuilder):
-    """.. versionadded:: 2.0
-
+    """
     Evaluates sustainability impact for a BoM in the Ansys Granta 2301 XML BoM format, and returns metrics for each
     item in the BoM.
 
@@ -1838,6 +1837,8 @@ class BomSustainabilityQuery(_SustainabilityMixin, _BomQueryBuilder):
     Once the query is fully constructed, use the `cxn.`
     :meth:`~ansys.grantami.bomanalytics._connection.BomAnalyticsClient.run` method to return a result of type
     :class:`~ansys.grantami.bomanalytics._query_results.BomSustainabilityQueryResult`.
+
+    .. versionadded:: 2.0
 
     Examples
     --------
@@ -1860,8 +1861,6 @@ class BomSustainabilityQuery(_SustainabilityMixin, _BomQueryBuilder):
 
 class BomSustainabilitySummaryQuery(_SustainabilityMixin, _BomQueryBuilder):
     """
-    .. versionadded:: 2.0
-
     Evaluates sustainability impact for a BoM in the Ansys Granta 2301 XML BoM format and returns aggregated metrics.
 
     The methods used to configure units and add the BoM to this query return the query itself so that they can be
@@ -1870,6 +1869,8 @@ class BomSustainabilitySummaryQuery(_SustainabilityMixin, _BomQueryBuilder):
     Once the query is fully constructed, use the `cxn.`
     :meth:`~ansys.grantami.bomanalytics._connection.BomAnalyticsClient.run` method to return a result of type
     :class:`~ansys.grantami.bomanalytics._query_results.BomSustainabilitySummaryQueryResult`.
+
+    .. versionadded:: 2.0
 
     Examples
     --------

--- a/src/ansys/grantami/bomanalytics/queries.py
+++ b/src/ansys/grantami/bomanalytics/queries.py
@@ -1827,7 +1827,9 @@ class _SustainabilityMixin(_ApiMixin):
 
 
 class BomSustainabilityQuery(_SustainabilityMixin, _BomQueryBuilder):
-    """Evaluates sustainability impact for a BoM in the Ansys Granta 2301 XML BoM format, and returns metrics for each
+    """.. versionadded:: 2.0
+
+    Evaluates sustainability impact for a BoM in the Ansys Granta 2301 XML BoM format, and returns metrics for each
     item in the BoM.
 
     The methods used to configure units and add the BoM to this query return the query itself so that they can be
@@ -1858,6 +1860,8 @@ class BomSustainabilityQuery(_SustainabilityMixin, _BomQueryBuilder):
 
 class BomSustainabilitySummaryQuery(_SustainabilityMixin, _BomQueryBuilder):
     """
+    .. versionadded:: 2.0
+
     Evaluates sustainability impact for a BoM in the Ansys Granta 2301 XML BoM format and returns aggregated metrics.
 
     The methods used to configure units and add the BoM to this query return the query itself so that they can be

--- a/src/ansys/grantami/bomanalytics/schemas/__init__.py
+++ b/src/ansys/grantami/bomanalytics/schemas/__init__.py
@@ -9,7 +9,15 @@ from pathlib import Path
 _schemas_dir = Path(__file__).parent
 
 bom_schema_1711: Path = _schemas_dir / "BillOfMaterialsEco1711.xsd"
-"""Path to the Ansys Granta 17/11 BoM XML Schema definition."""
+"""
+.. versionadded:: 2.0
+
+Path to the Ansys Granta 17/11 BoM XML Schema definition.
+"""
 
 bom_schema_2301: Path = _schemas_dir / "BillOfMaterialsEco2301.xsd"
-"""Path to the Ansys Granta 23/01 BoM XML Schema definition."""
+"""
+.. versionadded:: 2.0
+
+Path to the Ansys Granta 23/01 BoM XML Schema definition.
+"""

--- a/src/ansys/grantami/bomanalytics/schemas/__init__.py
+++ b/src/ansys/grantami/bomanalytics/schemas/__init__.py
@@ -9,15 +9,13 @@ from pathlib import Path
 _schemas_dir = Path(__file__).parent
 
 bom_schema_1711: Path = _schemas_dir / "BillOfMaterialsEco1711.xsd"
-"""
-Path to the Ansys Granta 17/11 BoM XML Schema definition.
+"""Path to the Ansys Granta 17/11 BoM XML Schema definition.
 
 .. versionadded:: 2.0
 """
 
 bom_schema_2301: Path = _schemas_dir / "BillOfMaterialsEco2301.xsd"
-"""
-Path to the Ansys Granta 23/01 BoM XML Schema definition.
+"""Path to the Ansys Granta 23/01 BoM XML Schema definition.
 
 .. versionadded:: 2.0
 """

--- a/src/ansys/grantami/bomanalytics/schemas/__init__.py
+++ b/src/ansys/grantami/bomanalytics/schemas/__init__.py
@@ -10,14 +10,14 @@ _schemas_dir = Path(__file__).parent
 
 bom_schema_1711: Path = _schemas_dir / "BillOfMaterialsEco1711.xsd"
 """
-.. versionadded:: 2.0
-
 Path to the Ansys Granta 17/11 BoM XML Schema definition.
+
+.. versionadded:: 2.0
 """
 
 bom_schema_2301: Path = _schemas_dir / "BillOfMaterialsEco2301.xsd"
 """
-.. versionadded:: 2.0
-
 Path to the Ansys Granta 23/01 BoM XML Schema definition.
+
+.. versionadded:: 2.0
 """


### PR DESCRIPTION
Closes #464 

Adds versionadded directives for all additions to the API since the initial release.

General approach was to add them for entire classes if the class is new, or individual properties or attributes if not. Also added to API pages. I didn't add the directive for every BoM type, because we want to keep this somewhat auto-generatable, and adding versionadded directives here wouldn't be possible with that approach.