### PR TITLE
Extend timeout

### DIFF
--- a/cicd/check_server.py
+++ b/cicd/check_server.py
@@ -12,7 +12,7 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger()
 
 MAX_ATTEMPTS = 30
-WAIT_TIME = 5
+WAIT_TIME = 15
 
 
 def block_until_server_is_ok(func):


### PR DESCRIPTION
Extend VM timeout - the new VM seems to be much slower at starting up than the previous one, which means CI always fails