### PR TITLE
Deploy docs after release to PyPI

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -50,13 +50,6 @@ jobs:
     needs: integration_checks
     runs-on: ubuntu-latest
     steps:
-      - name: "Deploy stable documentation"
-        uses: ansys/actions/doc-deploy-stable@v5
-        with:
-          cname: ${{ env.DOCUMENTATION_CNAME }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-          doc-artifact-name: Documentation-html
-
       - uses: actions/checkout@v4
 
       - name: Set up Python 3.9
@@ -102,3 +95,10 @@ jobs:
             dist/*.whl
             dist/documentation-html.zip
             dist/*.pdf
+
+      - name: "Deploy stable documentation"
+        uses: ansys/actions/doc-deploy-stable@v5
+        with:
+          cname: ${{ env.DOCUMENTATION_CNAME }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          doc-artifact-name: Documentation-html


### PR DESCRIPTION
The pyansys action does not support tags other than vMAJOR.MINOR.PATCH and therefore fails on alpha versions.
This PR moves the deploy docs step to the end of the release job. It won't prevent it from failing, so we'll need to find a better solution in the long term if the action isn't updated.