### PR TITLE
MAINT - Enable license check pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,3 +62,11 @@ repos:
   rev: 0.28.1
   hooks:
     - id: check-github-workflows
+
+- repo: https://github.com/ansys/pre-commit-hooks
+  rev: v0.2.8
+  hooks:
+    - id: add-license-headers
+      args:
+      - --start_year=2022
+      files: '(src|tests)/.*\.(py)'


### PR DESCRIPTION
Closes #484 

This PR adds the license check hook with a start year of 2022 per the release of 1.0. Run locally it passes with no changes, and if I remove a header it adds it back.