### PR TITLE
Update openapi-common reference link

### DIFF
--- a/doc/changelog.d/513.miscellaneous.md
+++ b/doc/changelog.d/513.miscellaneous.md
@@ -1,1 +1,1 @@
-Update openapi-common intersphinx link
+Update openapi-common reference link

--- a/doc/changelog.d/513.miscellaneous.md
+++ b/doc/changelog.d/513.miscellaneous.md
@@ -1,0 +1,1 @@
+Update openapi-common intersphinx link

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -79,13 +79,7 @@ autodoc_typehints_description_target = "documented"
 # Intersphinx mapping
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3.11", None),
-    "openapi-common": ("https://openapi.docs.pyansys.com", None),
-    # kept here as an example
-    # "scipy": ("https://docs.scipy.org/doc/scipy/reference", None),
-    # "numpy": ("https://numpy.org/devdocs", None),
-    # "matplotlib": ("https://matplotlib.org/stable", None),
-    # "pandas": ("https://pandas.pydata.org/pandas-docs/stable", None),
-    # "pyvista": ("https://docs.pyvista.org/", None),
+    "openapi-common": ("https://openapi.docs.pyansys.com/version/stable", None),
 }
 
 # numpydoc configuration


### PR DESCRIPTION
Update openapi-common intersphinx link to accomodate change in object inventory location. (caused by new multiversioned docs)