### PR TITLE
Fix cross-references to openapi-common

### DIFF
--- a/version/1.1/api/common.html
+++ b/version/1.1/api/common.html
@@ -440,25 +440,25 @@
 <dt class="sig sig-object py" id="ansys.grantami.bomanalytics.Connection">
 <em class="property"><span class="pre">class</span><span class="w"> </span></em><span class="sig-name descname"><span class="pre">Connection</span></span><span class="sig-paren">(</span><em class="sig-param"><span class="n"><span class="pre">api_url</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">session_configuration</span></span><span class="o"><span class="pre">=</span></span><span class="default_value"><span class="pre">None</span></span></em><span class="sig-paren">)</span><a class="headerlink" href="#ansys.grantami.bomanalytics.Connection" title="Permalink to this definition">#</a></dt>
 <dd><p>Connects to an instance of Granta MI.</p>
-<p>This is a subclass of the <a class="reference external" href="https://openapi.docs.pyansys.com/api/_autosummary/ansys.openapi.common.ApiClientFactory.html#ansys.openapi.common.ApiClientFactory" title="(in ansys.openapi.common v1.2.1)"><code class="xref py py-class docutils literal notranslate"><span class="pre">ansys.openapi.common.ApiClientFactory</span></code></a> class.
-All methods in this class are documented as returning <a class="reference external" href="https://openapi.docs.pyansys.com/api/_autosummary/ansys.openapi.common.ApiClientFactory.html#ansys.openapi.common.ApiClientFactory" title="(in ansys.openapi.common v1.2.1)"><code class="xref py py-class docutils literal notranslate"><span class="pre">ApiClientFactory</span></code></a>
+<p>This is a subclass of the <a class="reference external" href="https://openapi.docs.pyansys.com/version/stable/api/_autosummary/ansys.openapi.common.ApiClientFactory.html#ansys.openapi.common.ApiClientFactory" title="(in ansys.openapi.common v1.2.1)"><code class="xref py py-class docutils literal notranslate"><span class="pre">ansys.openapi.common.ApiClientFactory</span></code></a> class.
+All methods in this class are documented as returning <a class="reference external" href="https://openapi.docs.pyansys.com/version/stable/api/_autosummary/ansys.openapi.common.ApiClientFactory.html#ansys.openapi.common.ApiClientFactory" title="(in ansys.openapi.common v1.2.1)"><code class="xref py py-class docutils literal notranslate"><span class="pre">ApiClientFactory</span></code></a>
 class instances of the <a class="reference internal" href="#ansys.grantami.bomanalytics.Connection" title="ansys.grantami.bomanalytics.Connection"><code class="xref py py-class docutils literal notranslate"><span class="pre">ansys.grantami.bomanalytics.Connection</span></code></a> class instead.</p>
 <dl class="field-list">
 <dt class="field-odd">Parameters</dt>
 <dd class="field-odd"><dl>
 <dt><strong>api_url</strong><span class="classifier"><a class="reference external" href="https://docs.python.org/dev/library/stdtypes.html#str" title="(in Python v3.12)"><code class="docutils literal notranslate"><span class="pre">str</span></code></a></span></dt><dd><p>Base URL of the API server.</p>
 </dd>
-<dt><strong>session_configuration</strong><span class="classifier"><a class="reference external" href="https://openapi.docs.pyansys.com/api/_autosummary/ansys.openapi.common.SessionConfiguration.html#ansys.openapi.common.SessionConfiguration" title="(in ansys.openapi.common v1.2.1)"><code class="xref py py-class docutils literal notranslate"><span class="pre">SessionConfiguration</span></code></a>, <code class="xref py py-obj docutils literal notranslate"><span class="pre">optional</span></code></span></dt><dd><p>Additional configuration settings for the requests session. The default is <code class="docutils literal notranslate"><span class="pre">None</span></code>, in which case the
-<a class="reference external" href="https://openapi.docs.pyansys.com/api/_autosummary/ansys.openapi.common.SessionConfiguration.html#ansys.openapi.common.SessionConfiguration" title="(in ansys.openapi.common v1.2.1)"><code class="xref py py-class docutils literal notranslate"><span class="pre">SessionConfiguration</span></code></a> class with default parameters is used.</p>
+<dt><strong>session_configuration</strong><span class="classifier"><a class="reference external" href="https://openapi.docs.pyansys.com/version/stable/api/_autosummary/ansys.openapi.common.SessionConfiguration.html#ansys.openapi.common.SessionConfiguration" title="(in ansys.openapi.common v1.2.1)"><code class="xref py py-class docutils literal notranslate"><span class="pre">SessionConfiguration</span></code></a>, <code class="xref py py-obj docutils literal notranslate"><span class="pre">optional</span></code></span></dt><dd><p>Additional configuration settings for the requests session. The default is <code class="docutils literal notranslate"><span class="pre">None</span></code>, in which case the
+<a class="reference external" href="https://openapi.docs.pyansys.com/version/stable/api/_autosummary/ansys.openapi.common.SessionConfiguration.html#ansys.openapi.common.SessionConfiguration" title="(in ansys.openapi.common v1.2.1)"><code class="xref py py-class docutils literal notranslate"><span class="pre">SessionConfiguration</span></code></a> class with default parameters is used.</p>
 </dd>
 </dl>
 </dd>
 </dl>
 <p class="rubric">Notes</p>
 <p>For advanced usage, including configuring session-specific properties and timeouts, see the
-<a class="reference external" href="https://openapi.docs.pyansys.com/api/index.html" title="(in ansys.openapi.common v1.2.1)"><span class="xref std std-doc">ansys-openapi-common API reference</span></a>. Specifically, see the
-documentation for the <a class="reference external" href="https://openapi.docs.pyansys.com/api/_autosummary/ansys.openapi.common.ApiClientFactory.html#ansys.openapi.common.ApiClientFactory" title="(in ansys.openapi.common v1.2.1)"><code class="xref py py-class docutils literal notranslate"><span class="pre">ApiClientFactory</span></code></a> base class and the
-<a class="reference external" href="https://openapi.docs.pyansys.com/api/_autosummary/ansys.openapi.common.SessionConfiguration.html#ansys.openapi.common.SessionConfiguration" title="(in ansys.openapi.common v1.2.1)"><code class="xref py py-class docutils literal notranslate"><span class="pre">SessionConfiguration</span></code></a> class.</p>
+<a class="reference external" href="https://openapi.docs.pyansys.com/version/stable/api/index.html" title="(in ansys.openapi.common stable)"><span class="xref std std-doc">ansys-openapi-common API reference</span></a>. Specifically, see the
+documentation for the <a class="reference external" href="https://openapi.docs.pyansys.com/version/stable/api/_autosummary/ansys.openapi.common.ApiClientFactory.html#ansys.openapi.common.ApiClientFactory" title="(in ansys.openapi.common v1.2.1)"><code class="xref py py-class docutils literal notranslate"><span class="pre">ApiClientFactory</span></code></a> base class and the
+<a class="reference external" href="https://openapi.docs.pyansys.com/version/stable/api/_autosummary/ansys.openapi.common.SessionConfiguration.html#ansys.openapi.common.SessionConfiguration" title="(in ansys.openapi.common v1.2.1)"><code class="xref py py-class docutils literal notranslate"><span class="pre">SessionConfiguration</span></code></a> class.</p>
 <p>To create the connection to Granta MI, you perform three steps:</p>
 <ol class="arabic simple">
 <li><p>Create the connection builder object and specify the server to connect to.</p></li>
@@ -488,7 +488,7 @@ documentation for the <a class="reference external" href="https://openapi.docs.p
 <dl class="field-list simple">
 <dt class="field-odd">Returns</dt>
 <dd class="field-odd"><dl class="simple">
-<dt><a class="reference external" href="https://openapi.docs.pyansys.com/api/_autosummary/ansys.openapi.common.ApiClientFactory.html#ansys.openapi.common.ApiClientFactory" title="(in ansys.openapi.common v1.2.1)"><code class="xref py py-class docutils literal notranslate"><span class="pre">ApiClientFactory</span></code></a></dt><dd><p>Current client factory object.</p>
+<dt><a class="reference external" href="https://openapi.docs.pyansys.com/version/stable/api/_autosummary/ansys.openapi.common.ApiClientFactory.html#ansys.openapi.common.ApiClientFactory" title="(in ansys.openapi.common v1.2.1)"><code class="xref py py-class docutils literal notranslate"><span class="pre">ApiClientFactory</span></code></a></dt><dd><p>Current client factory object.</p>
 </dd>
 </dl>
 </dd>
@@ -522,7 +522,7 @@ configured for use.</p>
 </dd>
 <dt class="field-even">Returns</dt>
 <dd class="field-even"><dl class="simple">
-<dt><a class="reference external" href="https://openapi.docs.pyansys.com/api/_autosummary/ansys.openapi.common.ApiClientFactory.html#ansys.openapi.common.ApiClientFactory" title="(in ansys.openapi.common v1.2.1)"><code class="xref py py-class docutils literal notranslate"><span class="pre">ApiClientFactory</span></code></a></dt><dd><p>Original client factory object.</p>
+<dt><a class="reference external" href="https://openapi.docs.pyansys.com/version/stable/api/_autosummary/ansys.openapi.common.ApiClientFactory.html#ansys.openapi.common.ApiClientFactory" title="(in ansys.openapi.common v1.2.1)"><code class="xref py py-class docutils literal notranslate"><span class="pre">ApiClientFactory</span></code></a></dt><dd><p>Original client factory object.</p>
 </dd>
 </dl>
 </dd>
@@ -538,13 +538,13 @@ configured for use.</p>
 <dl class="field-list">
 <dt class="field-odd">Parameters</dt>
 <dd class="field-odd"><dl>
-<dt><strong>idp_session_configuration</strong><span class="classifier"><a class="reference external" href="https://openapi.docs.pyansys.com/api/_autosummary/ansys.openapi.common.SessionConfiguration.html#ansys.openapi.common.SessionConfiguration" title="(in ansys.openapi.common v1.2.1)"><code class="xref py py-class docutils literal notranslate"><span class="pre">SessionConfiguration</span></code></a>, <code class="xref py py-obj docutils literal notranslate"><span class="pre">optional</span></code></span></dt><dd><p>Additional configuration settings for the requests session when connected to the OpenID identity provider.</p>
+<dt><strong>idp_session_configuration</strong><span class="classifier"><a class="reference external" href="https://openapi.docs.pyansys.com/version/stable/api/_autosummary/ansys.openapi.common.SessionConfiguration.html#ansys.openapi.common.SessionConfiguration" title="(in ansys.openapi.common v1.2.1)"><code class="xref py py-class docutils literal notranslate"><span class="pre">SessionConfiguration</span></code></a>, <code class="xref py py-obj docutils literal notranslate"><span class="pre">optional</span></code></span></dt><dd><p>Additional configuration settings for the requests session when connected to the OpenID identity provider.</p>
 </dd>
 </dl>
 </dd>
 <dt class="field-even">Returns</dt>
 <dd class="field-even"><dl class="simple">
-<dt><a class="reference external" href="https://openapi.docs.pyansys.com/api/_autosummary/ansys.openapi.common.OIDCSessionBuilder.html#ansys.openapi.common.OIDCSessionBuilder" title="(in ansys.openapi.common v1.2.1)"><code class="xref py py-class docutils literal notranslate"><span class="pre">OIDCSessionBuilder</span></code></a></dt><dd><p>Builder object to authenticate via OIDC.</p>
+<dt><a class="reference external" href="https://openapi.docs.pyansys.com/version/stable/api/_autosummary/ansys.openapi.common.OIDCSessionBuilder.html#ansys.openapi.common.OIDCSessionBuilder" title="(in ansys.openapi.common v1.2.1)"><code class="xref py py-class docutils literal notranslate"><span class="pre">OIDCSessionBuilder</span></code></a></dt><dd><p>Builder object to authenticate via OIDC.</p>
 </dd>
 </dl>
 </dd>
@@ -563,7 +563,7 @@ method.</p>
 <dl class="field-list simple">
 <dt class="field-odd">Returns</dt>
 <dd class="field-odd"><dl class="simple">
-<dt><a class="reference external" href="https://openapi.docs.pyansys.com/api/_autosummary/ansys.openapi.common.ApiClientFactory.html#ansys.openapi.common.ApiClientFactory" title="(in ansys.openapi.common v1.2.1)"><code class="xref py py-class docutils literal notranslate"><span class="pre">ApiClientFactory</span></code></a></dt><dd><p>Original client factory object.</p>
+<dt><a class="reference external" href="https://openapi.docs.pyansys.com/version/stable/api/_autosummary/ansys.openapi.common.ApiClientFactory.html#ansys.openapi.common.ApiClientFactory" title="(in ansys.openapi.common v1.2.1)"><code class="xref py py-class docutils literal notranslate"><span class="pre">ApiClientFactory</span></code></a></dt><dd><p>Original client factory object.</p>
 </dd>
 </dl>
 </dd>
@@ -649,7 +649,7 @@ impacted substances results. In the case of a YAML query, a string is returned.<
 of <code class="docutils literal notranslate"><span class="pre">critical</span></code>. This indicates that Granta MI is running and the BoM Analytics service
 is available, but the query could not be run, probably because of a missing database or table.</p>
 </dd>
-<dt><a class="reference external" href="https://openapi.docs.pyansys.com/api/_autosummary/ansys.openapi.common.ApiException.html#ansys.openapi.common.ApiException" title="(in ansys.openapi.common v1.2.1)"><code class="xref py py-class docutils literal notranslate"><span class="pre">ApiException</span></code></a></dt><dd><p>Error raised if the Granta MI server is not able to return a response, probably
+<dt><a class="reference external" href="https://openapi.docs.pyansys.com/version/stable/api/_autosummary/ansys.openapi.common.ApiException.html#ansys.openapi.common.ApiException" title="(in ansys.openapi.common v1.2.1)"><code class="xref py py-class docutils literal notranslate"><span class="pre">ApiException</span></code></a></dt><dd><p>Error raised if the Granta MI server is not able to return a response, probably
 because of an internal configuration error or the BoM Analytics service not being installed.</p>
 </dd>
 </dl>

--- a/version/1.1/api/common.html
+++ b/version/1.1/api/common.html
@@ -456,7 +456,7 @@ class instances of the <a class="reference internal" href="#ansys.grantami.boman
 </dl>
 <p class="rubric">Notes</p>
 <p>For advanced usage, including configuring session-specific properties and timeouts, see the
-<a class="reference external" href="https://openapi.docs.pyansys.com/version/stable/api/index.html" title="(in ansys.openapi.common stable)"><span class="xref std std-doc">ansys-openapi-common API reference</span></a>. Specifically, see the
+<a class="reference external" href="https://openapi.docs.pyansys.com/version/stable/api/index.html" title="(in ansys.openapi.common v1.2.1)"><span class="xref std std-doc">ansys-openapi-common API reference</span></a>. Specifically, see the
 documentation for the <a class="reference external" href="https://openapi.docs.pyansys.com/version/stable/api/_autosummary/ansys.openapi.common.ApiClientFactory.html#ansys.openapi.common.ApiClientFactory" title="(in ansys.openapi.common v1.2.1)"><code class="xref py py-class docutils literal notranslate"><span class="pre">ApiClientFactory</span></code></a> base class and the
 <a class="reference external" href="https://openapi.docs.pyansys.com/version/stable/api/_autosummary/ansys.openapi.common.SessionConfiguration.html#ansys.openapi.common.SessionConfiguration" title="(in ansys.openapi.common v1.2.1)"><code class="xref py py-class docutils literal notranslate"><span class="pre">SessionConfiguration</span></code></a> class.</p>
 <p>To create the connection to Granta MI, you perform three steps:</p>

--- a/version/1.2/api/common.html
+++ b/version/1.2/api/common.html
@@ -477,7 +477,7 @@ class instances of the <a class="reference internal" href="#ansys.grantami.boman
 </dl>
 <p class="rubric">Notes</p>
 <p>For advanced usage, including configuring session-specific properties and timeouts, see the
-<a class="reference external" href="https://openapi.docs.pyansys.com/version/stable/api/index.html" title="(in ansys.openapi.common stable)"><span class="xref std std-doc">ansys-openapi-common API reference</span></a>. Specifically, see the
+<a class="reference external" href="https://openapi.docs.pyansys.com/version/stable/api/index.html" title="(in ansys.openapi.common v1.2.2)"><span class="xref std std-doc">ansys-openapi-common API reference</span></a>. Specifically, see the
 documentation for the <a class="reference external" href="https://openapi.docs.pyansys.com/version/stable/api/_autosummary/ansys.openapi.common.ApiClientFactory.html#ansys.openapi.common.ApiClientFactory" title="(in ansys.openapi.common v1.2.2)"><code class="xref py py-class docutils literal notranslate"><span class="pre">ApiClientFactory</span></code></a> base class and the
 <a class="reference external" href="https://openapi.docs.pyansys.com/version/stable/api/_autosummary/ansys.openapi.common.SessionConfiguration.html#ansys.openapi.common.SessionConfiguration" title="(in ansys.openapi.common v1.2.2)"><code class="xref py py-class docutils literal notranslate"><span class="pre">SessionConfiguration</span></code></a> class.</p>
 <p>To create the connection to Granta MI, you perform three steps:</p>

--- a/version/1.2/api/common.html
+++ b/version/1.2/api/common.html
@@ -461,25 +461,25 @@ document.write(`
 <dt class="sig sig-object py" id="ansys.grantami.bomanalytics.Connection">
 <em class="property"><span class="pre">class</span><span class="w"> </span></em><span class="sig-name descname"><span class="pre">Connection</span></span><span class="sig-paren">(</span><em class="sig-param"><span class="n"><span class="pre">api_url</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">session_configuration</span></span><span class="o"><span class="pre">=</span></span><span class="default_value"><span class="pre">None</span></span></em><span class="sig-paren">)</span><a class="headerlink" href="#ansys.grantami.bomanalytics.Connection" title="Permalink to this definition">#</a></dt>
 <dd><p>Connects to an instance of Granta MI.</p>
-<p>This is a subclass of the <a class="reference external" href="https://openapi.docs.pyansys.com/api/_autosummary/ansys.openapi.common.ApiClientFactory.html#ansys.openapi.common.ApiClientFactory" title="(in ansys.openapi.common v1.2.2)"><code class="xref py py-class docutils literal notranslate"><span class="pre">ansys.openapi.common.ApiClientFactory</span></code></a> class.
-All methods in this class are documented as returning <a class="reference external" href="https://openapi.docs.pyansys.com/api/_autosummary/ansys.openapi.common.ApiClientFactory.html#ansys.openapi.common.ApiClientFactory" title="(in ansys.openapi.common v1.2.2)"><code class="xref py py-class docutils literal notranslate"><span class="pre">ApiClientFactory</span></code></a>
+<p>This is a subclass of the <a class="reference external" href="https://openapi.docs.pyansys.com/version/stable/api/_autosummary/ansys.openapi.common.ApiClientFactory.html#ansys.openapi.common.ApiClientFactory" title="(in ansys.openapi.common v1.2.2)"><code class="xref py py-class docutils literal notranslate"><span class="pre">ansys.openapi.common.ApiClientFactory</span></code></a> class.
+All methods in this class are documented as returning <a class="reference external" href="https://openapi.docs.pyansys.com/version/stable/api/_autosummary/ansys.openapi.common.ApiClientFactory.html#ansys.openapi.common.ApiClientFactory" title="(in ansys.openapi.common v1.2.2)"><code class="xref py py-class docutils literal notranslate"><span class="pre">ApiClientFactory</span></code></a>
 class instances of the <a class="reference internal" href="#ansys.grantami.bomanalytics.Connection" title="ansys.grantami.bomanalytics.Connection"><code class="xref py py-class docutils literal notranslate"><span class="pre">ansys.grantami.bomanalytics.Connection</span></code></a> class instead.</p>
 <dl class="field-list">
 <dt class="field-odd">Parameters<span class="colon">:</span></dt>
 <dd class="field-odd"><dl>
 <dt><strong>api_url</strong><span class="classifier"><a class="reference external" href="https://docs.python.org/3.11/library/stdtypes.html#str" title="(in Python v3.11)"><code class="docutils literal notranslate"><span class="pre">str</span></code></a></span></dt><dd><p>Base URL of the API server.</p>
 </dd>
-<dt><strong>session_configuration</strong><span class="classifier"><a class="reference external" href="https://openapi.docs.pyansys.com/api/_autosummary/ansys.openapi.common.SessionConfiguration.html#ansys.openapi.common.SessionConfiguration" title="(in ansys.openapi.common v1.2.2)"><code class="xref py py-class docutils literal notranslate"><span class="pre">SessionConfiguration</span></code></a>, <code class="xref py py-obj docutils literal notranslate"><span class="pre">optional</span></code></span></dt><dd><p>Additional configuration settings for the requests session. The default is <code class="docutils literal notranslate"><span class="pre">None</span></code>, in which case the
-<a class="reference external" href="https://openapi.docs.pyansys.com/api/_autosummary/ansys.openapi.common.SessionConfiguration.html#ansys.openapi.common.SessionConfiguration" title="(in ansys.openapi.common v1.2.2)"><code class="xref py py-class docutils literal notranslate"><span class="pre">SessionConfiguration</span></code></a> class with default parameters is used.</p>
+<dt><strong>session_configuration</strong><span class="classifier"><a class="reference external" href="https://openapi.docs.pyansys.com/version/stable/api/_autosummary/ansys.openapi.common.SessionConfiguration.html#ansys.openapi.common.SessionConfiguration" title="(in ansys.openapi.common v1.2.2)"><code class="xref py py-class docutils literal notranslate"><span class="pre">SessionConfiguration</span></code></a>, <code class="xref py py-obj docutils literal notranslate"><span class="pre">optional</span></code></span></dt><dd><p>Additional configuration settings for the requests session. The default is <code class="docutils literal notranslate"><span class="pre">None</span></code>, in which case the
+<a class="reference external" href="https://openapi.docs.pyansys.com/version/stable/api/_autosummary/ansys.openapi.common.SessionConfiguration.html#ansys.openapi.common.SessionConfiguration" title="(in ansys.openapi.common v1.2.2)"><code class="xref py py-class docutils literal notranslate"><span class="pre">SessionConfiguration</span></code></a> class with default parameters is used.</p>
 </dd>
 </dl>
 </dd>
 </dl>
 <p class="rubric">Notes</p>
 <p>For advanced usage, including configuring session-specific properties and timeouts, see the
-<a class="reference external" href="https://openapi.docs.pyansys.com/api/index.html" title="(in ansys.openapi.common v1.2.2)"><span class="xref std std-doc">ansys-openapi-common API reference</span></a>. Specifically, see the
-documentation for the <a class="reference external" href="https://openapi.docs.pyansys.com/api/_autosummary/ansys.openapi.common.ApiClientFactory.html#ansys.openapi.common.ApiClientFactory" title="(in ansys.openapi.common v1.2.2)"><code class="xref py py-class docutils literal notranslate"><span class="pre">ApiClientFactory</span></code></a> base class and the
-<a class="reference external" href="https://openapi.docs.pyansys.com/api/_autosummary/ansys.openapi.common.SessionConfiguration.html#ansys.openapi.common.SessionConfiguration" title="(in ansys.openapi.common v1.2.2)"><code class="xref py py-class docutils literal notranslate"><span class="pre">SessionConfiguration</span></code></a> class.</p>
+<a class="reference external" href="https://openapi.docs.pyansys.com/version/stable/api/index.html" title="(in ansys.openapi.common stable)"><span class="xref std std-doc">ansys-openapi-common API reference</span></a>. Specifically, see the
+documentation for the <a class="reference external" href="https://openapi.docs.pyansys.com/version/stable/api/_autosummary/ansys.openapi.common.ApiClientFactory.html#ansys.openapi.common.ApiClientFactory" title="(in ansys.openapi.common v1.2.2)"><code class="xref py py-class docutils literal notranslate"><span class="pre">ApiClientFactory</span></code></a> base class and the
+<a class="reference external" href="https://openapi.docs.pyansys.com/version/stable/api/_autosummary/ansys.openapi.common.SessionConfiguration.html#ansys.openapi.common.SessionConfiguration" title="(in ansys.openapi.common v1.2.2)"><code class="xref py py-class docutils literal notranslate"><span class="pre">SessionConfiguration</span></code></a> class.</p>
 <p>To create the connection to Granta MI, you perform three steps:</p>
 <ol class="arabic simple">
 <li><p>Create the connection builder object and specify the server to connect to.</p></li>
@@ -509,7 +509,7 @@ documentation for the <a class="reference external" href="https://openapi.docs.p
 <dl class="field-list simple">
 <dt class="field-odd">Returns<span class="colon">:</span></dt>
 <dd class="field-odd"><dl class="simple">
-<dt><a class="reference external" href="https://openapi.docs.pyansys.com/api/_autosummary/ansys.openapi.common.ApiClientFactory.html#ansys.openapi.common.ApiClientFactory" title="(in ansys.openapi.common v1.2.2)"><code class="xref py py-class docutils literal notranslate"><span class="pre">ApiClientFactory</span></code></a></dt><dd><p>Current client factory object.</p>
+<dt><a class="reference external" href="https://openapi.docs.pyansys.com/version/stable/api/_autosummary/ansys.openapi.common.ApiClientFactory.html#ansys.openapi.common.ApiClientFactory" title="(in ansys.openapi.common v1.2.2)"><code class="xref py py-class docutils literal notranslate"><span class="pre">ApiClientFactory</span></code></a></dt><dd><p>Current client factory object.</p>
 </dd>
 </dl>
 </dd>
@@ -543,7 +543,7 @@ configured for use.</p>
 </dd>
 <dt class="field-even">Returns<span class="colon">:</span></dt>
 <dd class="field-even"><dl class="simple">
-<dt><a class="reference external" href="https://openapi.docs.pyansys.com/api/_autosummary/ansys.openapi.common.ApiClientFactory.html#ansys.openapi.common.ApiClientFactory" title="(in ansys.openapi.common v1.2.2)"><code class="xref py py-class docutils literal notranslate"><span class="pre">ApiClientFactory</span></code></a></dt><dd><p>Original client factory object.</p>
+<dt><a class="reference external" href="https://openapi.docs.pyansys.com/version/stable/api/_autosummary/ansys.openapi.common.ApiClientFactory.html#ansys.openapi.common.ApiClientFactory" title="(in ansys.openapi.common v1.2.2)"><code class="xref py py-class docutils literal notranslate"><span class="pre">ApiClientFactory</span></code></a></dt><dd><p>Original client factory object.</p>
 </dd>
 </dl>
 </dd>
@@ -559,13 +559,13 @@ configured for use.</p>
 <dl class="field-list">
 <dt class="field-odd">Parameters<span class="colon">:</span></dt>
 <dd class="field-odd"><dl>
-<dt><strong>idp_session_configuration</strong><span class="classifier"><a class="reference external" href="https://openapi.docs.pyansys.com/api/_autosummary/ansys.openapi.common.SessionConfiguration.html#ansys.openapi.common.SessionConfiguration" title="(in ansys.openapi.common v1.2.2)"><code class="xref py py-class docutils literal notranslate"><span class="pre">SessionConfiguration</span></code></a>, <code class="xref py py-obj docutils literal notranslate"><span class="pre">optional</span></code></span></dt><dd><p>Additional configuration settings for the requests session when connected to the OpenID identity provider.</p>
+<dt><strong>idp_session_configuration</strong><span class="classifier"><a class="reference external" href="https://openapi.docs.pyansys.com/version/stable/api/_autosummary/ansys.openapi.common.SessionConfiguration.html#ansys.openapi.common.SessionConfiguration" title="(in ansys.openapi.common v1.2.2)"><code class="xref py py-class docutils literal notranslate"><span class="pre">SessionConfiguration</span></code></a>, <code class="xref py py-obj docutils literal notranslate"><span class="pre">optional</span></code></span></dt><dd><p>Additional configuration settings for the requests session when connected to the OpenID identity provider.</p>
 </dd>
 </dl>
 </dd>
 <dt class="field-even">Returns<span class="colon">:</span></dt>
 <dd class="field-even"><dl class="simple">
-<dt><a class="reference external" href="https://openapi.docs.pyansys.com/api/_autosummary/ansys.openapi.common.OIDCSessionBuilder.html#ansys.openapi.common.OIDCSessionBuilder" title="(in ansys.openapi.common v1.2.2)"><code class="xref py py-class docutils literal notranslate"><span class="pre">OIDCSessionBuilder</span></code></a></dt><dd><p>Builder object to authenticate via OIDC.</p>
+<dt><a class="reference external" href="https://openapi.docs.pyansys.com/version/stable/api/_autosummary/ansys.openapi.common.OIDCSessionBuilder.html#ansys.openapi.common.OIDCSessionBuilder" title="(in ansys.openapi.common v1.2.2)"><code class="xref py py-class docutils literal notranslate"><span class="pre">OIDCSessionBuilder</span></code></a></dt><dd><p>Builder object to authenticate via OIDC.</p>
 </dd>
 </dl>
 </dd>
@@ -584,7 +584,7 @@ method.</p>
 <dl class="field-list simple">
 <dt class="field-odd">Returns<span class="colon">:</span></dt>
 <dd class="field-odd"><dl class="simple">
-<dt><a class="reference external" href="https://openapi.docs.pyansys.com/api/_autosummary/ansys.openapi.common.ApiClientFactory.html#ansys.openapi.common.ApiClientFactory" title="(in ansys.openapi.common v1.2.2)"><code class="xref py py-class docutils literal notranslate"><span class="pre">ApiClientFactory</span></code></a></dt><dd><p>Original client factory object.</p>
+<dt><a class="reference external" href="https://openapi.docs.pyansys.com/version/stable/api/_autosummary/ansys.openapi.common.ApiClientFactory.html#ansys.openapi.common.ApiClientFactory" title="(in ansys.openapi.common v1.2.2)"><code class="xref py py-class docutils literal notranslate"><span class="pre">ApiClientFactory</span></code></a></dt><dd><p>Original client factory object.</p>
 </dd>
 </dl>
 </dd>
@@ -697,7 +697,7 @@ impacted substances results. In the case of a YAML query, a string is returned.<
 of <code class="docutils literal notranslate"><span class="pre">critical</span></code>. This indicates that Granta MI is running and the BoM Analytics service
 is available, but the query could not be run, probably because of a missing database or table.</p>
 </dd>
-<dt><a class="reference external" href="https://openapi.docs.pyansys.com/api/_autosummary/ansys.openapi.common.ApiException.html#ansys.openapi.common.ApiException" title="(in ansys.openapi.common v1.2.2)"><code class="xref py py-class docutils literal notranslate"><span class="pre">ApiException</span></code></a></dt><dd><p>Error raised if the Granta MI server is not able to return a response, probably
+<dt><a class="reference external" href="https://openapi.docs.pyansys.com/version/stable/api/_autosummary/ansys.openapi.common.ApiException.html#ansys.openapi.common.ApiException" title="(in ansys.openapi.common v1.2.2)"><code class="xref py py-class docutils literal notranslate"><span class="pre">ApiException</span></code></a></dt><dd><p>Error raised if the Granta MI server is not able to return a response, probably
 because of an internal configuration error or the BoM Analytics service not being installed.</p>
 </dd>
 </dl>

--- a/version/2.0/api/common.html
+++ b/version/2.0/api/common.html
@@ -506,25 +506,25 @@ document.write(`
 <dt class="sig sig-object py" id="ansys.grantami.bomanalytics.Connection">
 <em class="property"><span class="pre">class</span><span class="w"> </span></em><span class="sig-name descname"><span class="pre">Connection</span></span><span class="sig-paren">(</span><em class="sig-param"><span class="n"><span class="pre">api_url</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">session_configuration</span></span><span class="o"><span class="pre">=</span></span><span class="default_value"><span class="pre">None</span></span></em><span class="sig-paren">)</span><a class="headerlink" href="#ansys.grantami.bomanalytics.Connection" title="Link to this definition">#</a></dt>
 <dd><p>Connects to an instance of Granta MI.</p>
-<p>This is a subclass of the <a class="reference external" href="https://openapi.docs.pyansys.com/api/_autosummary/ansys.openapi.common.ApiClientFactory.html#ansys.openapi.common.ApiClientFactory" title="(in ansys.openapi.common v1.4.0)"><code class="xref py py-class docutils literal notranslate"><span class="pre">ansys.openapi.common.ApiClientFactory</span></code></a> class.
-All methods in this class are documented as returning <a class="reference external" href="https://openapi.docs.pyansys.com/api/_autosummary/ansys.openapi.common.ApiClientFactory.html#ansys.openapi.common.ApiClientFactory" title="(in ansys.openapi.common v1.4.0)"><code class="xref py py-class docutils literal notranslate"><span class="pre">ApiClientFactory</span></code></a>
+<p>This is a subclass of the <a class="reference external" href="https://openapi.docs.pyansys.com/version/stable/api/_autosummary/ansys.openapi.common.ApiClientFactory.html#ansys.openapi.common.ApiClientFactory" title="(in ansys.openapi.common v1.4.0)"><code class="xref py py-class docutils literal notranslate"><span class="pre">ansys.openapi.common.ApiClientFactory</span></code></a> class.
+All methods in this class are documented as returning <a class="reference external" href="https://openapi.docs.pyansys.com/version/stable/api/_autosummary/ansys.openapi.common.ApiClientFactory.html#ansys.openapi.common.ApiClientFactory" title="(in ansys.openapi.common v1.4.0)"><code class="xref py py-class docutils literal notranslate"><span class="pre">ApiClientFactory</span></code></a>
 class instances of the <a class="reference internal" href="#ansys.grantami.bomanalytics.Connection" title="ansys.grantami.bomanalytics.Connection"><code class="xref py py-class docutils literal notranslate"><span class="pre">ansys.grantami.bomanalytics.Connection</span></code></a> class instead.</p>
 <dl class="field-list">
 <dt class="field-odd">Parameters<span class="colon">:</span></dt>
 <dd class="field-odd"><dl>
 <dt><strong>api_url</strong><span class="classifier"><a class="reference external" href="https://docs.python.org/3.11/library/stdtypes.html#str" title="(in Python v3.11)"><code class="docutils literal notranslate"><span class="pre">str</span></code></a></span></dt><dd><p>Base URL of the API server.</p>
 </dd>
-<dt><strong>session_configuration</strong><span class="classifier"><a class="reference external" href="https://openapi.docs.pyansys.com/api/_autosummary/ansys.openapi.common.SessionConfiguration.html#ansys.openapi.common.SessionConfiguration" title="(in ansys.openapi.common v1.4.0)"><code class="xref py py-class docutils literal notranslate"><span class="pre">SessionConfiguration</span></code></a>, optional</span></dt><dd><p>Additional configuration settings for the requests session. The default is <code class="docutils literal notranslate"><span class="pre">None</span></code>, in which case the
-<a class="reference external" href="https://openapi.docs.pyansys.com/api/_autosummary/ansys.openapi.common.SessionConfiguration.html#ansys.openapi.common.SessionConfiguration" title="(in ansys.openapi.common v1.4.0)"><code class="xref py py-class docutils literal notranslate"><span class="pre">SessionConfiguration</span></code></a> class with default parameters is used.</p>
+<dt><strong>session_configuration</strong><span class="classifier"><a class="reference external" href="https://openapi.docs.pyansys.com/version/stable/api/_autosummary/ansys.openapi.common.SessionConfiguration.html#ansys.openapi.common.SessionConfiguration" title="(in ansys.openapi.common v1.4.0)"><code class="xref py py-class docutils literal notranslate"><span class="pre">SessionConfiguration</span></code></a>, optional</span></dt><dd><p>Additional configuration settings for the requests session. The default is <code class="docutils literal notranslate"><span class="pre">None</span></code>, in which case the
+<a class="reference external" href="https://openapi.docs.pyansys.com/version/stable/api/_autosummary/ansys.openapi.common.SessionConfiguration.html#ansys.openapi.common.SessionConfiguration" title="(in ansys.openapi.common v1.4.0)"><code class="xref py py-class docutils literal notranslate"><span class="pre">SessionConfiguration</span></code></a> class with default parameters is used.</p>
 </dd>
 </dl>
 </dd>
 </dl>
 <p class="rubric">Notes</p>
 <p>For advanced usage, including configuring session-specific properties and timeouts, see the
-<a class="reference external" href="https://openapi.docs.pyansys.com/api/index.html" title="(in ansys.openapi.common v1.4.0)"><span class="xref std std-doc">ansys-openapi-common API reference</span></a>. Specifically, see the
-documentation for the <a class="reference external" href="https://openapi.docs.pyansys.com/api/_autosummary/ansys.openapi.common.ApiClientFactory.html#ansys.openapi.common.ApiClientFactory" title="(in ansys.openapi.common v1.4.0)"><code class="xref py py-class docutils literal notranslate"><span class="pre">ApiClientFactory</span></code></a> base class and the
-<a class="reference external" href="https://openapi.docs.pyansys.com/api/_autosummary/ansys.openapi.common.SessionConfiguration.html#ansys.openapi.common.SessionConfiguration" title="(in ansys.openapi.common v1.4.0)"><code class="xref py py-class docutils literal notranslate"><span class="pre">SessionConfiguration</span></code></a> class.</p>
+<a class="reference external" href="https://openapi.docs.pyansys.com/version/stable/api/index.html" title="(in ansys.openapi.common stable)"><span class="xref std std-doc">ansys-openapi-common API reference</span></a>. Specifically, see the
+documentation for the <a class="reference external" href="https://openapi.docs.pyansys.com/version/stable/api/_autosummary/ansys.openapi.common.ApiClientFactory.html#ansys.openapi.common.ApiClientFactory" title="(in ansys.openapi.common v1.4.0)"><code class="xref py py-class docutils literal notranslate"><span class="pre">ApiClientFactory</span></code></a> base class and the
+<a class="reference external" href="https://openapi.docs.pyansys.com/version/stable/api/_autosummary/ansys.openapi.common.SessionConfiguration.html#ansys.openapi.common.SessionConfiguration" title="(in ansys.openapi.common v1.4.0)"><code class="xref py py-class docutils literal notranslate"><span class="pre">SessionConfiguration</span></code></a> class.</p>
 <p>To create the connection to Granta MI, you perform three steps:</p>
 <ol class="arabic simple">
 <li><p>Create the connection builder object and specify the server to connect to.</p></li>
@@ -554,7 +554,7 @@ documentation for the <a class="reference external" href="https://openapi.docs.p
 <dl class="field-list simple">
 <dt class="field-odd">Returns<span class="colon">:</span></dt>
 <dd class="field-odd"><dl class="simple">
-<dt><a class="reference external" href="https://openapi.docs.pyansys.com/api/_autosummary/ansys.openapi.common.ApiClientFactory.html#ansys.openapi.common.ApiClientFactory" title="(in ansys.openapi.common v1.4.0)"><code class="xref py py-class docutils literal notranslate"><span class="pre">ApiClientFactory</span></code></a></dt><dd><p>Current client factory object.</p>
+<dt><a class="reference external" href="https://openapi.docs.pyansys.com/version/stable/api/_autosummary/ansys.openapi.common.ApiClientFactory.html#ansys.openapi.common.ApiClientFactory" title="(in ansys.openapi.common v1.4.0)"><code class="xref py py-class docutils literal notranslate"><span class="pre">ApiClientFactory</span></code></a></dt><dd><p>Current client factory object.</p>
 </dd>
 </dl>
 </dd>
@@ -588,7 +588,7 @@ configured for use.</p>
 </dd>
 <dt class="field-even">Returns<span class="colon">:</span></dt>
 <dd class="field-even"><dl class="simple">
-<dt><a class="reference external" href="https://openapi.docs.pyansys.com/api/_autosummary/ansys.openapi.common.ApiClientFactory.html#ansys.openapi.common.ApiClientFactory" title="(in ansys.openapi.common v1.4.0)"><code class="xref py py-class docutils literal notranslate"><span class="pre">ApiClientFactory</span></code></a></dt><dd><p>Original client factory object.</p>
+<dt><a class="reference external" href="https://openapi.docs.pyansys.com/version/stable/api/_autosummary/ansys.openapi.common.ApiClientFactory.html#ansys.openapi.common.ApiClientFactory" title="(in ansys.openapi.common v1.4.0)"><code class="xref py py-class docutils literal notranslate"><span class="pre">ApiClientFactory</span></code></a></dt><dd><p>Original client factory object.</p>
 </dd>
 </dl>
 </dd>
@@ -604,13 +604,13 @@ configured for use.</p>
 <dl class="field-list">
 <dt class="field-odd">Parameters<span class="colon">:</span></dt>
 <dd class="field-odd"><dl>
-<dt><strong>idp_session_configuration</strong><span class="classifier"><a class="reference external" href="https://openapi.docs.pyansys.com/api/_autosummary/ansys.openapi.common.SessionConfiguration.html#ansys.openapi.common.SessionConfiguration" title="(in ansys.openapi.common v1.4.0)"><code class="xref py py-class docutils literal notranslate"><span class="pre">SessionConfiguration</span></code></a>, optional</span></dt><dd><p>Additional configuration settings for the requests session when connected to the OpenID identity provider.</p>
+<dt><strong>idp_session_configuration</strong><span class="classifier"><a class="reference external" href="https://openapi.docs.pyansys.com/version/stable/api/_autosummary/ansys.openapi.common.SessionConfiguration.html#ansys.openapi.common.SessionConfiguration" title="(in ansys.openapi.common v1.4.0)"><code class="xref py py-class docutils literal notranslate"><span class="pre">SessionConfiguration</span></code></a>, optional</span></dt><dd><p>Additional configuration settings for the requests session when connected to the OpenID identity provider.</p>
 </dd>
 </dl>
 </dd>
 <dt class="field-even">Returns<span class="colon">:</span></dt>
 <dd class="field-even"><dl class="simple">
-<dt><a class="reference external" href="https://openapi.docs.pyansys.com/api/_autosummary/ansys.openapi.common.OIDCSessionBuilder.html#ansys.openapi.common.OIDCSessionBuilder" title="(in ansys.openapi.common v1.4.0)"><code class="xref py py-class docutils literal notranslate"><span class="pre">OIDCSessionBuilder</span></code></a></dt><dd><p>Builder object to authenticate via OIDC.</p>
+<dt><a class="reference external" href="https://openapi.docs.pyansys.com/version/stable/api/_autosummary/ansys.openapi.common.OIDCSessionBuilder.html#ansys.openapi.common.OIDCSessionBuilder" title="(in ansys.openapi.common v1.4.0)"><code class="xref py py-class docutils literal notranslate"><span class="pre">OIDCSessionBuilder</span></code></a></dt><dd><p>Builder object to authenticate via OIDC.</p>
 </dd>
 </dl>
 </dd>
@@ -629,7 +629,7 @@ method.</p>
 <dl class="field-list simple">
 <dt class="field-odd">Returns<span class="colon">:</span></dt>
 <dd class="field-odd"><dl class="simple">
-<dt><a class="reference external" href="https://openapi.docs.pyansys.com/api/_autosummary/ansys.openapi.common.ApiClientFactory.html#ansys.openapi.common.ApiClientFactory" title="(in ansys.openapi.common v1.4.0)"><code class="xref py py-class docutils literal notranslate"><span class="pre">ApiClientFactory</span></code></a></dt><dd><p>Original client factory object.</p>
+<dt><a class="reference external" href="https://openapi.docs.pyansys.com/version/stable/api/_autosummary/ansys.openapi.common.ApiClientFactory.html#ansys.openapi.common.ApiClientFactory" title="(in ansys.openapi.common v1.4.0)"><code class="xref py py-class docutils literal notranslate"><span class="pre">ApiClientFactory</span></code></a></dt><dd><p>Original client factory object.</p>
 </dd>
 </dl>
 </dd>
@@ -744,7 +744,7 @@ impacted substances, or sustainability results.</p>
 of <code class="docutils literal notranslate"><span class="pre">critical</span></code>. This indicates that Granta MI is running and the BoM Analytics service
 is available, but the query could not be run, probably because of a missing database or table.</p>
 </dd>
-<dt><a class="reference external" href="https://openapi.docs.pyansys.com/api/_autosummary/ansys.openapi.common.ApiException.html#ansys.openapi.common.ApiException" title="(in ansys.openapi.common v1.4.0)"><code class="xref py py-class docutils literal notranslate"><span class="pre">ApiException</span></code></a></dt><dd><p>Error raised if the Granta MI server is not able to return a response, probably
+<dt><a class="reference external" href="https://openapi.docs.pyansys.com/version/stable/api/_autosummary/ansys.openapi.common.ApiException.html#ansys.openapi.common.ApiException" title="(in ansys.openapi.common v1.4.0)"><code class="xref py py-class docutils literal notranslate"><span class="pre">ApiException</span></code></a></dt><dd><p>Error raised if the Granta MI server is not able to return a response, probably
 because of an internal configuration error or the BoM Analytics service not being installed.</p>
 </dd>
 </dl>

--- a/version/2.0/api/common.html
+++ b/version/2.0/api/common.html
@@ -522,7 +522,7 @@ class instances of the <a class="reference internal" href="#ansys.grantami.boman
 </dl>
 <p class="rubric">Notes</p>
 <p>For advanced usage, including configuring session-specific properties and timeouts, see the
-<a class="reference external" href="https://openapi.docs.pyansys.com/version/stable/api/index.html" title="(in ansys.openapi.common stable)"><span class="xref std std-doc">ansys-openapi-common API reference</span></a>. Specifically, see the
+<a class="reference external" href="https://openapi.docs.pyansys.com/version/stable/api/index.html" title="(in ansys.openapi.common v1.4.0)"><span class="xref std std-doc">ansys-openapi-common API reference</span></a>. Specifically, see the
 documentation for the <a class="reference external" href="https://openapi.docs.pyansys.com/version/stable/api/_autosummary/ansys.openapi.common.ApiClientFactory.html#ansys.openapi.common.ApiClientFactory" title="(in ansys.openapi.common v1.4.0)"><code class="xref py py-class docutils literal notranslate"><span class="pre">ApiClientFactory</span></code></a> base class and the
 <a class="reference external" href="https://openapi.docs.pyansys.com/version/stable/api/_autosummary/ansys.openapi.common.SessionConfiguration.html#ansys.openapi.common.SessionConfiguration" title="(in ansys.openapi.common v1.4.0)"><code class="xref py py-class docutils literal notranslate"><span class="pre">SessionConfiguration</span></code></a> class.</p>
 <p>To create the connection to Granta MI, you perform three steps:</p>

--- a/version/dev/api/common.html
+++ b/version/dev/api/common.html
@@ -536,7 +536,7 @@ class instances of the <a class="reference internal" href="#ansys.grantami.boman
 </dl>
 <p class="rubric">Notes</p>
 <p>For advanced usage, including configuring session-specific properties and timeouts, see the
-<a class="reference external" href="https://openapi.docs.pyansys.com/version/stable/api/index.html" title="(in ansys.openapi.common stable)"><span class="xref std std-doc">ansys-openapi-common API reference</span></a>. Specifically, see the
+<a class="reference external" href="https://openapi.docs.pyansys.com/version/stable/api/index.html" title="(in ansys.openapi.common v2.0.2)"><span class="xref std std-doc">ansys-openapi-common API reference</span></a>. Specifically, see the
 documentation for the <a class="reference external" href="https://openapi.docs.pyansys.com/version/stable/api/_autosummary/ansys.openapi.common.ApiClientFactory.html#ansys.openapi.common.ApiClientFactory" title="(in ansys.openapi.common v2.0.2)"><code class="xref py py-class docutils literal notranslate"><span class="pre">ApiClientFactory</span></code></a> base class and the
 <a class="reference external" href="https://openapi.docs.pyansys.com/version/stable/api/_autosummary/ansys.openapi.common.SessionConfiguration.html#ansys.openapi.common.SessionConfiguration" title="(in ansys.openapi.common v2.0.2)"><code class="xref py py-class docutils literal notranslate"><span class="pre">SessionConfiguration</span></code></a> class.</p>
 <p>To create the connection to Granta MI, you perform three steps:</p>

--- a/version/dev/api/common.html
+++ b/version/dev/api/common.html
@@ -536,7 +536,7 @@ class instances of the <a class="reference internal" href="#ansys.grantami.boman
 </dl>
 <p class="rubric">Notes</p>
 <p>For advanced usage, including configuring session-specific properties and timeouts, see the
-<a class="reference external" href="https://openapi.docs.pyansys.com/version/stable/api/index.html" title="(in ansys.openapi.common v2.0.2)"><span class="xref std std-doc">ansys-openapi-common API reference</span></a>. Specifically, see the
+<a class="reference external" href="https://openapi.docs.pyansys.com/version/stable/api/index.html" title="(in ansys.openapi.common stable)"><span class="xref std std-doc">ansys-openapi-common API reference</span></a>. Specifically, see the
 documentation for the <a class="reference external" href="https://openapi.docs.pyansys.com/version/stable/api/_autosummary/ansys.openapi.common.ApiClientFactory.html#ansys.openapi.common.ApiClientFactory" title="(in ansys.openapi.common v2.0.2)"><code class="xref py py-class docutils literal notranslate"><span class="pre">ApiClientFactory</span></code></a> base class and the
 <a class="reference external" href="https://openapi.docs.pyansys.com/version/stable/api/_autosummary/ansys.openapi.common.SessionConfiguration.html#ansys.openapi.common.SessionConfiguration" title="(in ansys.openapi.common v2.0.2)"><code class="xref py py-class docutils literal notranslate"><span class="pre">SessionConfiguration</span></code></a> class.</p>
 <p>To create the connection to Granta MI, you perform three steps:</p>

--- a/version/stable/api/common.html
+++ b/version/stable/api/common.html
@@ -506,25 +506,25 @@ document.write(`
 <dt class="sig sig-object py" id="ansys.grantami.bomanalytics.Connection">
 <em class="property"><span class="pre">class</span><span class="w"> </span></em><span class="sig-name descname"><span class="pre">Connection</span></span><span class="sig-paren">(</span><em class="sig-param"><span class="n"><span class="pre">api_url</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">session_configuration</span></span><span class="o"><span class="pre">=</span></span><span class="default_value"><span class="pre">None</span></span></em><span class="sig-paren">)</span><a class="headerlink" href="#ansys.grantami.bomanalytics.Connection" title="Link to this definition">#</a></dt>
 <dd><p>Connects to an instance of Granta MI.</p>
-<p>This is a subclass of the <a class="reference external" href="https://openapi.docs.pyansys.com/api/_autosummary/ansys.openapi.common.ApiClientFactory.html#ansys.openapi.common.ApiClientFactory" title="(in ansys.openapi.common v1.4.0)"><code class="xref py py-class docutils literal notranslate"><span class="pre">ansys.openapi.common.ApiClientFactory</span></code></a> class.
-All methods in this class are documented as returning <a class="reference external" href="https://openapi.docs.pyansys.com/api/_autosummary/ansys.openapi.common.ApiClientFactory.html#ansys.openapi.common.ApiClientFactory" title="(in ansys.openapi.common v1.4.0)"><code class="xref py py-class docutils literal notranslate"><span class="pre">ApiClientFactory</span></code></a>
+<p>This is a subclass of the <a class="reference external" href="https://openapi.docs.pyansys.com/version/stable/api/_autosummary/ansys.openapi.common.ApiClientFactory.html#ansys.openapi.common.ApiClientFactory" title="(in ansys.openapi.common v1.4.0)"><code class="xref py py-class docutils literal notranslate"><span class="pre">ansys.openapi.common.ApiClientFactory</span></code></a> class.
+All methods in this class are documented as returning <a class="reference external" href="https://openapi.docs.pyansys.com/version/stable/api/_autosummary/ansys.openapi.common.ApiClientFactory.html#ansys.openapi.common.ApiClientFactory" title="(in ansys.openapi.common v1.4.0)"><code class="xref py py-class docutils literal notranslate"><span class="pre">ApiClientFactory</span></code></a>
 class instances of the <a class="reference internal" href="#ansys.grantami.bomanalytics.Connection" title="ansys.grantami.bomanalytics.Connection"><code class="xref py py-class docutils literal notranslate"><span class="pre">ansys.grantami.bomanalytics.Connection</span></code></a> class instead.</p>
 <dl class="field-list">
 <dt class="field-odd">Parameters<span class="colon">:</span></dt>
 <dd class="field-odd"><dl>
 <dt><strong>api_url</strong><span class="classifier"><a class="reference external" href="https://docs.python.org/3.11/library/stdtypes.html#str" title="(in Python v3.11)"><code class="docutils literal notranslate"><span class="pre">str</span></code></a></span></dt><dd><p>Base URL of the API server.</p>
 </dd>
-<dt><strong>session_configuration</strong><span class="classifier"><a class="reference external" href="https://openapi.docs.pyansys.com/api/_autosummary/ansys.openapi.common.SessionConfiguration.html#ansys.openapi.common.SessionConfiguration" title="(in ansys.openapi.common v1.4.0)"><code class="xref py py-class docutils literal notranslate"><span class="pre">SessionConfiguration</span></code></a>, optional</span></dt><dd><p>Additional configuration settings for the requests session. The default is <code class="docutils literal notranslate"><span class="pre">None</span></code>, in which case the
-<a class="reference external" href="https://openapi.docs.pyansys.com/api/_autosummary/ansys.openapi.common.SessionConfiguration.html#ansys.openapi.common.SessionConfiguration" title="(in ansys.openapi.common v1.4.0)"><code class="xref py py-class docutils literal notranslate"><span class="pre">SessionConfiguration</span></code></a> class with default parameters is used.</p>
+<dt><strong>session_configuration</strong><span class="classifier"><a class="reference external" href="https://openapi.docs.pyansys.com/version/stable/api/_autosummary/ansys.openapi.common.SessionConfiguration.html#ansys.openapi.common.SessionConfiguration" title="(in ansys.openapi.common v1.4.0)"><code class="xref py py-class docutils literal notranslate"><span class="pre">SessionConfiguration</span></code></a>, optional</span></dt><dd><p>Additional configuration settings for the requests session. The default is <code class="docutils literal notranslate"><span class="pre">None</span></code>, in which case the
+<a class="reference external" href="https://openapi.docs.pyansys.com/version/stable/api/_autosummary/ansys.openapi.common.SessionConfiguration.html#ansys.openapi.common.SessionConfiguration" title="(in ansys.openapi.common v1.4.0)"><code class="xref py py-class docutils literal notranslate"><span class="pre">SessionConfiguration</span></code></a> class with default parameters is used.</p>
 </dd>
 </dl>
 </dd>
 </dl>
 <p class="rubric">Notes</p>
 <p>For advanced usage, including configuring session-specific properties and timeouts, see the
-<a class="reference external" href="https://openapi.docs.pyansys.com/api/index.html" title="(in ansys.openapi.common v1.4.0)"><span class="xref std std-doc">ansys-openapi-common API reference</span></a>. Specifically, see the
-documentation for the <a class="reference external" href="https://openapi.docs.pyansys.com/api/_autosummary/ansys.openapi.common.ApiClientFactory.html#ansys.openapi.common.ApiClientFactory" title="(in ansys.openapi.common v1.4.0)"><code class="xref py py-class docutils literal notranslate"><span class="pre">ApiClientFactory</span></code></a> base class and the
-<a class="reference external" href="https://openapi.docs.pyansys.com/api/_autosummary/ansys.openapi.common.SessionConfiguration.html#ansys.openapi.common.SessionConfiguration" title="(in ansys.openapi.common v1.4.0)"><code class="xref py py-class docutils literal notranslate"><span class="pre">SessionConfiguration</span></code></a> class.</p>
+<a class="reference external" href="https://openapi.docs.pyansys.com/version/stable/api/index.html" title="(in ansys.openapi.common stable)"><span class="xref std std-doc">ansys-openapi-common API reference</span></a>. Specifically, see the
+documentation for the <a class="reference external" href="https://openapi.docs.pyansys.com/version/stable/api/_autosummary/ansys.openapi.common.ApiClientFactory.html#ansys.openapi.common.ApiClientFactory" title="(in ansys.openapi.common v1.4.0)"><code class="xref py py-class docutils literal notranslate"><span class="pre">ApiClientFactory</span></code></a> base class and the
+<a class="reference external" href="https://openapi.docs.pyansys.com/version/stable/api/_autosummary/ansys.openapi.common.SessionConfiguration.html#ansys.openapi.common.SessionConfiguration" title="(in ansys.openapi.common v1.4.0)"><code class="xref py py-class docutils literal notranslate"><span class="pre">SessionConfiguration</span></code></a> class.</p>
 <p>To create the connection to Granta MI, you perform three steps:</p>
 <ol class="arabic simple">
 <li><p>Create the connection builder object and specify the server to connect to.</p></li>
@@ -554,7 +554,7 @@ documentation for the <a class="reference external" href="https://openapi.docs.p
 <dl class="field-list simple">
 <dt class="field-odd">Returns<span class="colon">:</span></dt>
 <dd class="field-odd"><dl class="simple">
-<dt><a class="reference external" href="https://openapi.docs.pyansys.com/api/_autosummary/ansys.openapi.common.ApiClientFactory.html#ansys.openapi.common.ApiClientFactory" title="(in ansys.openapi.common v1.4.0)"><code class="xref py py-class docutils literal notranslate"><span class="pre">ApiClientFactory</span></code></a></dt><dd><p>Current client factory object.</p>
+<dt><a class="reference external" href="https://openapi.docs.pyansys.com/version/stable/api/_autosummary/ansys.openapi.common.ApiClientFactory.html#ansys.openapi.common.ApiClientFactory" title="(in ansys.openapi.common v1.4.0)"><code class="xref py py-class docutils literal notranslate"><span class="pre">ApiClientFactory</span></code></a></dt><dd><p>Current client factory object.</p>
 </dd>
 </dl>
 </dd>
@@ -588,7 +588,7 @@ configured for use.</p>
 </dd>
 <dt class="field-even">Returns<span class="colon">:</span></dt>
 <dd class="field-even"><dl class="simple">
-<dt><a class="reference external" href="https://openapi.docs.pyansys.com/api/_autosummary/ansys.openapi.common.ApiClientFactory.html#ansys.openapi.common.ApiClientFactory" title="(in ansys.openapi.common v1.4.0)"><code class="xref py py-class docutils literal notranslate"><span class="pre">ApiClientFactory</span></code></a></dt><dd><p>Original client factory object.</p>
+<dt><a class="reference external" href="https://openapi.docs.pyansys.com/version/stable/api/_autosummary/ansys.openapi.common.ApiClientFactory.html#ansys.openapi.common.ApiClientFactory" title="(in ansys.openapi.common v1.4.0)"><code class="xref py py-class docutils literal notranslate"><span class="pre">ApiClientFactory</span></code></a></dt><dd><p>Original client factory object.</p>
 </dd>
 </dl>
 </dd>
@@ -604,13 +604,13 @@ configured for use.</p>
 <dl class="field-list">
 <dt class="field-odd">Parameters<span class="colon">:</span></dt>
 <dd class="field-odd"><dl>
-<dt><strong>idp_session_configuration</strong><span class="classifier"><a class="reference external" href="https://openapi.docs.pyansys.com/api/_autosummary/ansys.openapi.common.SessionConfiguration.html#ansys.openapi.common.SessionConfiguration" title="(in ansys.openapi.common v1.4.0)"><code class="xref py py-class docutils literal notranslate"><span class="pre">SessionConfiguration</span></code></a>, optional</span></dt><dd><p>Additional configuration settings for the requests session when connected to the OpenID identity provider.</p>
+<dt><strong>idp_session_configuration</strong><span class="classifier"><a class="reference external" href="https://openapi.docs.pyansys.com/version/stable/api/_autosummary/ansys.openapi.common.SessionConfiguration.html#ansys.openapi.common.SessionConfiguration" title="(in ansys.openapi.common v1.4.0)"><code class="xref py py-class docutils literal notranslate"><span class="pre">SessionConfiguration</span></code></a>, optional</span></dt><dd><p>Additional configuration settings for the requests session when connected to the OpenID identity provider.</p>
 </dd>
 </dl>
 </dd>
 <dt class="field-even">Returns<span class="colon">:</span></dt>
 <dd class="field-even"><dl class="simple">
-<dt><a class="reference external" href="https://openapi.docs.pyansys.com/api/_autosummary/ansys.openapi.common.OIDCSessionBuilder.html#ansys.openapi.common.OIDCSessionBuilder" title="(in ansys.openapi.common v1.4.0)"><code class="xref py py-class docutils literal notranslate"><span class="pre">OIDCSessionBuilder</span></code></a></dt><dd><p>Builder object to authenticate via OIDC.</p>
+<dt><a class="reference external" href="https://openapi.docs.pyansys.com/version/stable/api/_autosummary/ansys.openapi.common.OIDCSessionBuilder.html#ansys.openapi.common.OIDCSessionBuilder" title="(in ansys.openapi.common v1.4.0)"><code class="xref py py-class docutils literal notranslate"><span class="pre">OIDCSessionBuilder</span></code></a></dt><dd><p>Builder object to authenticate via OIDC.</p>
 </dd>
 </dl>
 </dd>
@@ -629,7 +629,7 @@ method.</p>
 <dl class="field-list simple">
 <dt class="field-odd">Returns<span class="colon">:</span></dt>
 <dd class="field-odd"><dl class="simple">
-<dt><a class="reference external" href="https://openapi.docs.pyansys.com/api/_autosummary/ansys.openapi.common.ApiClientFactory.html#ansys.openapi.common.ApiClientFactory" title="(in ansys.openapi.common v1.4.0)"><code class="xref py py-class docutils literal notranslate"><span class="pre">ApiClientFactory</span></code></a></dt><dd><p>Original client factory object.</p>
+<dt><a class="reference external" href="https://openapi.docs.pyansys.com/version/stable/api/_autosummary/ansys.openapi.common.ApiClientFactory.html#ansys.openapi.common.ApiClientFactory" title="(in ansys.openapi.common v1.4.0)"><code class="xref py py-class docutils literal notranslate"><span class="pre">ApiClientFactory</span></code></a></dt><dd><p>Original client factory object.</p>
 </dd>
 </dl>
 </dd>
@@ -744,7 +744,7 @@ impacted substances, or sustainability results.</p>
 of <code class="docutils literal notranslate"><span class="pre">critical</span></code>. This indicates that Granta MI is running and the BoM Analytics service
 is available, but the query could not be run, probably because of a missing database or table.</p>
 </dd>
-<dt><a class="reference external" href="https://openapi.docs.pyansys.com/api/_autosummary/ansys.openapi.common.ApiException.html#ansys.openapi.common.ApiException" title="(in ansys.openapi.common v1.4.0)"><code class="xref py py-class docutils literal notranslate"><span class="pre">ApiException</span></code></a></dt><dd><p>Error raised if the Granta MI server is not able to return a response, probably
+<dt><a class="reference external" href="https://openapi.docs.pyansys.com/version/stable/api/_autosummary/ansys.openapi.common.ApiException.html#ansys.openapi.common.ApiException" title="(in ansys.openapi.common v1.4.0)"><code class="xref py py-class docutils literal notranslate"><span class="pre">ApiException</span></code></a></dt><dd><p>Error raised if the Granta MI server is not able to return a response, probably
 because of an internal configuration error or the BoM Analytics service not being installed.</p>
 </dd>
 </dl>

--- a/version/stable/api/common.html
+++ b/version/stable/api/common.html
@@ -522,7 +522,7 @@ class instances of the <a class="reference internal" href="#ansys.grantami.boman
 </dl>
 <p class="rubric">Notes</p>
 <p>For advanced usage, including configuring session-specific properties and timeouts, see the
-<a class="reference external" href="https://openapi.docs.pyansys.com/version/stable/api/index.html" title="(in ansys.openapi.common stable)"><span class="xref std std-doc">ansys-openapi-common API reference</span></a>. Specifically, see the
+<a class="reference external" href="https://openapi.docs.pyansys.com/version/stable/api/index.html" title="(in ansys.openapi.common v1.4.0)"><span class="xref std std-doc">ansys-openapi-common API reference</span></a>. Specifically, see the
 documentation for the <a class="reference external" href="https://openapi.docs.pyansys.com/version/stable/api/_autosummary/ansys.openapi.common.ApiClientFactory.html#ansys.openapi.common.ApiClientFactory" title="(in ansys.openapi.common v1.4.0)"><code class="xref py py-class docutils literal notranslate"><span class="pre">ApiClientFactory</span></code></a> base class and the
 <a class="reference external" href="https://openapi.docs.pyansys.com/version/stable/api/_autosummary/ansys.openapi.common.SessionConfiguration.html#ansys.openapi.common.SessionConfiguration" title="(in ansys.openapi.common v1.4.0)"><code class="xref py py-class docutils literal notranslate"><span class="pre">SessionConfiguration</span></code></a> class.</p>
 <p>To create the connection to Granta MI, you perform three steps:</p>


### PR DESCRIPTION
Closes #516 

Replace `https://openapi.docs.pyansys.com/` with `https://openapi.docs.pyansys.com/version/stable/api`.

I noticed that the link to the general 'API documentation' includes a version number in the `title` attribute, which I believe is what the version happened to be when the documentation was built. I believe this will continue, even referring to the 'stable' version of the intersphinx mapping file, I don't think there's much we can really do about this.

Fairly certain this catches them all.