### PR TITLE
Do not run changelog-fragment for dependabot-initiated PRs

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -49,6 +49,7 @@ jobs:
         contents: write
         pull-requests: write
       runs-on: ubuntu-latest
+      if: ${{ !startsWith( github.event.pull_request.head.ref, 'dependabot/') }}
       steps:
       - uses: ansys/actions/doc-changelog@v6
         with:

--- a/doc/changelog.d/519.changed.md
+++ b/doc/changelog.d/519.changed.md
@@ -1,0 +1,1 @@
+Do not run changelog-fragment for dependabot-initiated PRs


### PR DESCRIPTION
Closes #515 

Don't run changelog-fragment for dependabot-initiated PRs to avoid dependabot PRs being 'frozen' by someone other than dependabot modifying the branch.

CI on this branch won't be affected, but I'm opening this PR for discussion. @klmcadams I've added you since you've been involved in some of our adventures with the new changelog actions.