### PR TITLE
Empty elements are no longer removed when deserializing a BoM file

### DIFF
--- a/doc/changelog.d/546.fixed.md
+++ b/doc/changelog.d/546.fixed.md
@@ -1,0 +1,1 @@
+Empty elements are no longer removed when deserializing a BoM file

--- a/src/ansys/grantami/bomanalytics/_bom_helper.py
+++ b/src/ansys/grantami/bomanalytics/_bom_helper.py
@@ -21,7 +21,7 @@
 # SOFTWARE.
 
 from pathlib import Path
-from typing import TYPE_CHECKING, Tuple, cast
+from typing import TYPE_CHECKING, Any, Dict, List, TextIO, Tuple, Union, cast
 
 import xmlschema
 from xmlschema import XMLSchema
@@ -63,7 +63,7 @@ class BoMHandler:
         :class:`~._bom_types.BillOfMaterials`
         """
         with open(file_path, "r", encoding="utf8") as fp:
-            obj, errors = cast(Tuple, self._schema.decode(fp, validation="lax", xmlns_processing="collapsed"))
+            obj, errors = self._deserialize_bom(fp)
 
         if len(errors) > 0:
             newline = "\n"
@@ -86,9 +86,7 @@ class BoMHandler:
         -------
         :class:`~._bom_types.BillOfMaterials`
         """
-        obj, errors = cast(
-            Tuple, self._schema.decode(bom_text, validation="lax", keep_empty=True, xmlns_processing="collapsed")
-        )
+        obj, errors = self._deserialize_bom(bom_text)
 
         if len(errors) > 0:
             newline = "\n"
@@ -97,6 +95,23 @@ class BoMHandler:
         assert isinstance(obj, dict)
 
         return self._reader.read_bom(obj)
+
+    def _deserialize_bom(self, bom: Union[TextIO, str]) -> Tuple[Dict[str, Any], List]:
+        """
+        Deserialize either a string or I/O stream BoM.
+
+        Parameters
+        ----------
+        bom : Union[TextIO, str]
+            Object containing an XML representation of a BoM, either as text or I/O stream.
+
+        Returns
+        -------
+        Tuple[Dict[str, Any], List]
+            A tuple of the deserialized dictionary and a list of errors.
+        """
+        result = self._schema.decode(bom, validation="lax", keep_empty=True, xmlns_processing="collapsed")
+        return cast(Tuple[Dict[str, Any], List], result)
 
     def dump_bom(self, bom: "BillOfMaterials") -> str:
         """

--- a/tests/inputs/__init__.py
+++ b/tests/inputs/__init__.py
@@ -28,25 +28,25 @@ repository_root = pathlib.Path(__file__).parents[2]
 inputs_dir = pathlib.Path(__file__).parent
 
 _sample_bom_1711_path = inputs_dir / "bom.xml"
-with open(_sample_bom_1711_path, "r") as f:
+with open(_sample_bom_1711_path, "r", encoding="utf8") as f:
     sample_bom_1711 = f.read()
 
 _sample_compliance_bom_1711_path = (
     repository_root / "examples" / "3_Advanced_Topics" / "supporting-files" / "bom-complex.xml"
 )
-with open(_sample_compliance_bom_1711_path, "r") as f:
+with open(_sample_compliance_bom_1711_path, "r", encoding="utf8") as f:
     sample_compliance_bom_1711 = f.read()
 
 sample_bom_custom_db = sample_compliance_bom_1711.replace(
     "MI_Restricted_Substances", "MI_Restricted_Substances_Custom_Tables"
 )
 
-_sample_sustainability_bom_2301_path = (
+sample_sustainability_bom_2301_path = (
     repository_root / "examples" / "4_Sustainability" / "supporting-files" / "bom-2301-assembly.xml"
 )
-with open(_sample_sustainability_bom_2301_path, "r") as f:
+with open(sample_sustainability_bom_2301_path, "r", encoding="utf8") as f:
     sample_sustainability_bom_2301 = f.read()
 
-_large_bom_2301_path = inputs_dir / "medium-test-bom.xml"
-with open(_large_bom_2301_path, "r") as f:
+large_bom_2301_path = inputs_dir / "medium-test-bom.xml"
+with open(large_bom_2301_path, "r", encoding="utf8") as f:
     large_bom_2301 = f.read()

--- a/tests/inputs/bom.xml
+++ b/tests/inputs/bom.xml
@@ -24,7 +24,7 @@
                 <Part>
                     <Quantity Unit="Each">1.0</Quantity>
                     <MassPerUom Unit="kg/Part">2.0</MassPerUom>
-                    <PartNumber>3333</PartNumber>
+                    <PartNumber />
                     <Name>Part Two</Name>
                     <Materials>
                         <Material>


### PR DESCRIPTION
Closes #545 

Standardizes the options used when deserializing a BoM from a file and from a string. Previously, `keep_empty=True` was only specified when reading a BoM from string, which caused a weird asymmetry in some situations.

This PR removes this duplication, and adds some tests that check deserializing and round-tripping a BoM with an empty element works both via a file and via text.