### PR TITLE
Use trusted publisher

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -155,13 +155,15 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-library, server-checks, update-changelog]
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
+    permissions:
+      id-token: write
+      contents: write
     steps:
       - uses: ansys/actions/release-pypi-public@v6
         name: "Release to public PyPI"
         with:
           library-name: ${{ env.LIBRARY_NAME }}
-          twine-username: "__token__"
-          twine-token: ${{ secrets.PYPI_TOKEN }}
+          use-trusted-publisher: true
 
       - uses: ansys/actions/release-github@v6
         name: "Release to GitHub"

--- a/doc/changelog.d/549.changed.md
+++ b/doc/changelog.d/549.changed.md
@@ -1,0 +1,1 @@
+Use trusted publisher


### PR DESCRIPTION
#543 

Modify release CI to use the trusted publisher approach to pushing releases to PyPI