### PR TITLE
Don't create changelog fragments for pre-commit updates

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -58,7 +58,7 @@ jobs:
         contents: write
         pull-requests: write
       runs-on: ubuntu-latest
-      if: ${{ !startsWith( github.event.pull_request.head.ref, 'dependabot/') }}
+      if: ${{ !startsWith( github.event.pull_request.head.ref, 'dependabot/') && !(startsWith(github.event.pull_request.head.ref, 'pre-commit-ci-update-config')) }}
       steps:
       - uses: ansys/actions/doc-changelog@v6
         with:

--- a/doc/changelog.d/587.changed.md
+++ b/doc/changelog.d/587.changed.md
@@ -1,0 +1,1 @@
+Don't create changelog fragments for pre-commit updates


### PR DESCRIPTION
Ignore pre-commit-ci PRs for changelog fragment creation.