### PR TITLE
Configure environment for trusted publisher release

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -155,6 +155,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-library, server-checks, update-changelog]
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
+    environment: release
     permissions:
       id-token: write
       contents: write

--- a/doc/changelog.d/617.maintenance.md
+++ b/doc/changelog.d/617.maintenance.md
@@ -1,0 +1,1 @@
+Configure environment for trusted publisher release


### PR DESCRIPTION
Closes #543 

The release action is already using the trusted publisher approach (#549 ), just adding the environment setting.