### PR TITLE
Add link to PyGranta version compatibility documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -75,7 +75,7 @@ run this command:
 
     pip install ansys-grantami-bomanalytics
 
-To install a release compatible with a specific version of Granta MI install the
+To install a release compatible with a specific version of Granta MI, install the
 `PyGranta <https://grantami.docs.pyansys.com/>`_ metapackage with a requirement specifier:
 
 .. code::

--- a/README.rst
+++ b/README.rst
@@ -68,7 +68,7 @@ Installation
 ------------
 .. readme_installation
 
-To install the latest PyGranta JobQueue release from `PyPI <https://pypi.org/project/ansys-grantami-bomanalytics/>`_,
+To install the latest PyGranta BoM Analytics release from `PyPI <https://pypi.org/project/ansys-grantami-bomanalytics/>`_,
 run this command:
 
 .. code::

--- a/README.rst
+++ b/README.rst
@@ -75,7 +75,9 @@ run this command:
 
     pip install ansys-grantami-bomanalytics
 
-To install a release compatible with a specific version of Granta MI, install the
+To install a release compatible with a specific version of Granta MI, consult the
+`Package versions <https://grantami.docs.pyansys.com/version/dev/package_versions.html>`_ section of the metapackage
+documentation, or install the
 `PyGranta <https://grantami.docs.pyansys.com/>`_ metapackage with a requirement specifier:
 
 .. code::

--- a/README.rst
+++ b/README.rst
@@ -75,14 +75,16 @@ run this command:
 
     pip install ansys-grantami-bomanalytics
 
-To install a release compatible with a specific version of Granta MI, consult the
-`Package versions <https://grantami.docs.pyansys.com/version/dev/package_versions.html>`_ section of the metapackage
-documentation, or install the
+To install a release compatible with a specific version of Granta MI install the
 `PyGranta <https://grantami.docs.pyansys.com/>`_ metapackage with a requirement specifier:
 
 .. code::
 
     pip install pygranta==2023.2.0
+
+To see which individual PyGranta package versions are installed with each version of the PyGranta metapackage, consult
+the `Package versions <https://grantami.docs.pyansys.com/version/dev/package_versions.html>`_ section of the PyGranta
+documentation.
 
 Alternatively, to install the latest development version from the `PyGranta BoM Analytics repository <https://github.com/ansys/grantami-bomanalytics>`_,
 run this command:

--- a/doc/changelog.d/620.documentation.md
+++ b/doc/changelog.d/620.documentation.md
@@ -1,0 +1,1 @@
+Add link to PyGranta version compatibility documentation


### PR DESCRIPTION
Add a link to the new page that lists dependencies and their versions for each MI version.
Fix a typo.