### PR TITLE
Add link to supported authentication schemes

### DIFF
--- a/doc/changelog.d/621.documentation.md
+++ b/doc/changelog.d/621.documentation.md
@@ -1,0 +1,1 @@
+Add link to supported authentication schemes

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -118,7 +118,8 @@ extlinks = {
     'MI_docs': (
         'https://ansyshelp.ansys.com/account/secured?returnurl=/Views/Secured/Granta/v241/en/RS_and_Sustainability/%s',
         None
-    )
+    ),
+    "OpenAPI-Common": ("https://openapi.docs.pyansys.com/version/stable/%s", None),
 }
 
 # static path

--- a/doc/source/getting_started/index.rst
+++ b/doc/source/getting_started/index.rst
@@ -31,6 +31,8 @@ Check that you can start the BomServices client from Python by running this code
 
     <BomServicesClient: url="my.server.name", dbkey="MI_Restricted_Substances">
 
+This example uses Windows-based autologon authentication. For all supported authentication schemes, see the :OpenAPI-Common:`OpenAPI-Common documentation <index.html#authentication-schemes>`.
+
 If you see a response from the server, congratulations. You can start using
 the BomAnalytics service. For information about available queries,
 see :ref:`ref_grantami_bomanalytics_examples`. For more in-depth descriptions,

--- a/doc/styles/config/vocabularies/ANSYS/accept.txt
+++ b/doc/styles/config/vocabularies/ANSYS/accept.txt
@@ -12,3 +12,4 @@ Makefile
 Jupytext
 subpackage
 THIRDPARTY
+autologon


### PR DESCRIPTION
https://github.com/ansys/pygranta/issues/109

Adds a link on the `Getting started` page to the list of auth schemes supported by OpenAPI-Common.