### PR TITLE
Improve VM management in CI

### DIFF
--- a/.github/workflows/server_checks.yml
+++ b/.github/workflows/server_checks.yml
@@ -148,12 +148,13 @@ jobs:
     name: Check if there are active workflow runs
     needs: doc-build
     uses: ansys/pygranta/.github/workflows/check-concurrent-workflows.yml@main
+    if: ${{ !cancelled() }}
 
   stop-vm:
     name: "Stop Azure VM"
     runs-on: ubuntu-latest
     needs: check-workflow-runs
-    if: ${{ always() && !(inputs.skip-vm-management)}}
+    if: ${{ !cancelled() && !(inputs.skip-vm-management) && needs.check-workflow-runs.outputs.active-runs != 'true'}}
     steps:
       - uses: azure/CLI@v2
         with:

--- a/doc/changelog.d/622.maintenance.md
+++ b/doc/changelog.d/622.maintenance.md
@@ -1,0 +1,1 @@
+Fix VM management conditions

--- a/doc/changelog.d/622.maintenance.md
+++ b/doc/changelog.d/622.maintenance.md
@@ -1,1 +1,1 @@
-Fix VM management conditions
+Improve VM management in CI


### PR DESCRIPTION
When integration tests failed, the job to check whether there are other active workflow runs was skipped and the VM was always turned off.
Adds a condition on the check_workflow_runs job to always run, unless the whole workflow has been cancelled, in which case the VM shutdown is also skipped.