### PR TITLE
Update Ansys documentation links to 2025 R1

### DIFF
--- a/doc/changelog.d/649.documentation.md
+++ b/doc/changelog.d/649.documentation.md
@@ -1,0 +1,1 @@
+Update Ansys documentation links to 2025 R1

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -116,7 +116,7 @@ numpydoc_validation_exclude = {
 
 extlinks = {
     'MI_docs': (
-        'https://ansyshelp.ansys.com/account/secured?returnurl=/Views/Secured/Granta/v241/en/RS_and_Sustainability/%s',
+        'https://ansyshelp.ansys.com/account/secured?returnurl=/Views/Secured/Granta/v251/en/RS_and_Sustainability/%s',
         None
     ),
     "OpenAPI-Common": ("https://openapi.docs.pyansys.com/version/stable/%s", None),


### PR DESCRIPTION
Closes #648

Update Ansys doc reference to v251. I have manually checked, and all the docs that use this string work on the internal QA site.