### PR TITLE
Use 2024 R2 Ansys documentation

### DIFF
--- a/doc/changelog.d/654.documentation.md
+++ b/doc/changelog.d/654.documentation.md
@@ -1,0 +1,1 @@
+Use 2024 R2 Ansys documentation

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -116,7 +116,7 @@ numpydoc_validation_exclude = {
 
 extlinks = {
     'MI_docs': (
-        'https://ansyshelp.ansys.com/account/secured?returnurl=/Views/Secured/Granta/v251/en/RS_and_Sustainability/%s',
+        'https://ansyshelp.ansys.com/account/secured?returnurl=/Views/Secured/Granta/v242/en/RS_and_Sustainability/%s',
         None
     ),
     "OpenAPI-Common": ("https://openapi.docs.pyansys.com/version/stable/%s", None),


### PR DESCRIPTION
Closes #653 

Use the 2024 R2 documentation site for core software documentation references. Unlike https://github.com/ansys/grantami-recordlists/pull/340 we can't use the public documentation, because the Restricted Substances and Sustainability documentation is only available behind a login.

We have to use the 2024 R2 documentation, because the 2025 R1 documentation will be released after this package.