### PR TITLE
Update stated Python requirement

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -59,7 +59,7 @@ to a Granta MI server that includes MI Restricted Substances and Sustainability 
 ``MI Restricted Substances`` and ``MI Sustainability`` are licensed separately.
 Endpoints available to end users depend on the available licenses.
 
-The ``ansys.grantami.bomanalytics`` package currently supports Python version 3.9 through 3.12.
+The ``ansys.grantami.bomanalytics`` package currently supports Python version 3.10 through 3.13.
 
 .. readme_software_requirements_end
 

--- a/doc/changelog.d/656.documentation.md
+++ b/doc/changelog.d/656.documentation.md
@@ -1,0 +1,1 @@
+Update stated Python requirement


### PR DESCRIPTION
Update stated Python requirement to 3.10 to 3.13.

I did think about removing this entirely, since we have the badges that give the Python version. The badges are not in the HTML documentation though, so we probably need to keep this line in place, 