### PR TITLE
Add missing space to ConnectionError text

### DIFF
--- a/doc/changelog.d/672.fixed.md
+++ b/doc/changelog.d/672.fixed.md
@@ -1,0 +1,1 @@
+Add missing space to ConnectionError text

--- a/src/ansys/grantami/bomanalytics/_connection.py
+++ b/src/ansys/grantami/bomanalytics/_connection.py
@@ -214,7 +214,7 @@ class Connection(ApiClientFactory):
             if e.status_code == 404:
                 raise ConnectionError(
                     "Cannot find the BoM Analytics service in Granta MI Service Layer. Ensure a compatible version of "
-                    "the Restricted Substances And Sustainability Reports are available on the server and try again."
+                    "the Restricted Substances And Sustainability Reports are available on the server and try again. "
                     "The minimum required Restricted Substances And Sustainability Reports version is "
                     f"{'.'.join([str(e) for e in MINIMUM_BAS_VERSION])}."
                 )


### PR DESCRIPTION
Add missing space to ConnectionError text when BoM Analytics Services is missing.