### PR TITLE
Optionally raise exceptions if a BoM can't be fully deserialized

### DIFF
--- a/doc/changelog.d/702.added.md
+++ b/doc/changelog.d/702.added.md
@@ -1,0 +1,1 @@
+Optionally raise exceptions if a BoM can't be fully deserialized

--- a/src/ansys/grantami/bomanalytics/_bom_helper.py
+++ b/src/ansys/grantami/bomanalytics/_bom_helper.py
@@ -69,10 +69,11 @@ class BoMHandler:
         Raises
         ------
         ValueError
-            If the BoM cannot be deserialized.
+            If the BoM cannot be deserialized. Additional detail is included in the exception message.
         ValueError
             If the BoM contains data that cannot be represented by the classes in the
-            :ref:`ref_grantami_bomanalytics_bom_api` and ``allow_unsupported_data = False`` is specified.
+            :ref:`ref_grantami_bomanalytics_bom_api` and ``allow_unsupported_data = False`` is specified. The additional
+            data is reported in the exception message.
         """
         with open(file_path, "r", encoding="utf8") as fp:
             obj, errors = self._deserialize_bom(fp)
@@ -86,7 +87,7 @@ class BoMHandler:
         bom, undeserialized_fields = self._reader.read_bom(obj)
         if undeserialized_fields and not allow_unsupported_data:
             self._raise_undeserialized_fields(undeserialized_fields)
-        return cast("BillOfMaterials", bom)
+        return bom
 
     def load_bom_from_text(self, bom_text: str, allow_unsupported_data: bool = True) -> "BillOfMaterials":
         """
@@ -108,10 +109,11 @@ class BoMHandler:
         Raises
         ------
         ValueError
-            If the BoM cannot be deserialized.
+            If the BoM cannot be deserialized. Additional detail is included in the exception message.
         ValueError
             If the BoM contains data that cannot be represented by the classes in the
-            :ref:`ref_grantami_bomanalytics_bom_api` and ``allow_unsupported_data = False`` is specified.
+            :ref:`ref_grantami_bomanalytics_bom_api` and ``allow_unsupported_data = False`` is specified. The additional
+            data is reported in the exception message.
         """
         obj, errors = self._deserialize_bom(bom_text)
 
@@ -124,7 +126,7 @@ class BoMHandler:
         bom, undeserialized_fields = self._reader.read_bom(obj)
         if undeserialized_fields and not allow_unsupported_data:
             self._raise_undeserialized_fields(undeserialized_fields)
-        return cast("BillOfMaterials", bom)
+        return bom
 
     @staticmethod
     def _raise_undeserialized_fields(fields: list[str]) -> None:

--- a/src/ansys/grantami/bomanalytics/_bom_helper.py
+++ b/src/ansys/grantami/bomanalytics/_bom_helper.py
@@ -71,8 +71,8 @@ class BoMHandler:
         ValueError
             If the BoM cannot be deserialized.
         ValueError
-            If the BoM contains data that cannot be represented by the classes in :mod:`.bom_types` and
-            ``allow_unsupported_data = False`` is specified.
+            If the BoM contains data that cannot be represented by the classes in the
+            :ref:`ref_grantami_bomanalytics_bom_api` and ``allow_unsupported_data = False`` is specified.
         """
         with open(file_path, "r", encoding="utf8") as fp:
             obj, errors = self._deserialize_bom(fp)
@@ -110,8 +110,8 @@ class BoMHandler:
         ValueError
             If the BoM cannot be deserialized.
         ValueError
-            If the BoM contains data that cannot be represented by the classes in :mod:`.bom_types` and
-            ``allow_unsupported_data = False`` is specified.
+            If the BoM contains data that cannot be represented by the classes in the
+            :ref:`ref_grantami_bomanalytics_bom_api` and ``allow_unsupported_data = False`` is specified.
         """
         obj, errors = self._deserialize_bom(bom_text)
 

--- a/src/ansys/grantami/bomanalytics/bom_types/_bom_reader.py
+++ b/src/ansys/grantami/bomanalytics/bom_types/_bom_reader.py
@@ -86,6 +86,7 @@ class BoMReader:
         Recursively deserialize a dictionary of XML fields to a hierarchy of Python objects.
         Keeps track of any fields which have not been deserialized, so they can be optionally reported to the user
         following deserialization.
+
         Parameters
         ----------
         type_name : str

--- a/src/ansys/grantami/bomanalytics/bom_types/_bom_reader.py
+++ b/src/ansys/grantami/bomanalytics/bom_types/_bom_reader.py
@@ -53,7 +53,7 @@ class BoMReader:
         # Used to track fields in an object that haven't been deserialized.
         self.__undeserialized_fields: list[str] = []
 
-    def read_bom(self, obj: Dict) -> tuple["BaseType", list]:
+    def read_bom(self, obj: Dict) -> tuple["BillOfMaterials", list]:
         """
         Convert a BoM object from xmlschema JSON format into a BillOfMaterials object.
 

--- a/tests/inputs/__init__.py
+++ b/tests/inputs/__init__.py
@@ -50,3 +50,7 @@ with open(sample_sustainability_bom_2301_path, "r", encoding="utf8") as f:
 large_bom_2301_path = inputs_dir / "medium-test-bom.xml"
 with open(large_bom_2301_path, "r", encoding="utf8") as f:
     large_bom_2301 = f.read()
+
+bom_with_annotations_path = inputs_dir / "bom-with-annotations.xml"
+with open(bom_with_annotations_path, "r", encoding="utf8") as f:
+    bom_with_annotations = f.read()

--- a/tests/inputs/bom-with-annotations.xml
+++ b/tests/inputs/bom-with-annotations.xml
@@ -1,0 +1,56 @@
+<PartsEco xmlns="http://www.grantadesign.com/23/01/BillOfMaterialsEco" xmlns:gbt="http://www.grantadesign.com/12/05/GrantaBaseTypes" id="B0">
+    <Components>
+        <Part id="A0">
+            <Quantity Unit="Each">2.0</Quantity>
+            <PartNumber>123456789</PartNumber>
+            <Name>Part One</Name>
+            <Components>
+                <Part>
+                    <Quantity Unit="Each">1.0</Quantity>
+                    <MassPerUom Unit="kg/Part">2.0</MassPerUom>
+                    <PartNumber>987654321</PartNumber>
+                    <Name>New Part One</Name>
+                    <Substances>
+                        <Substance>
+                            <Percentage>66.0</Percentage>
+                            <MISubstanceReference>
+                                <gbt:dbKey>MI_Restricted_Substances</gbt:dbKey>
+                                <gbt:recordHistoryGUID>af1cb650-6db5-49d6-b4a2-0eee9a090207</gbt:recordHistoryGUID>
+                            </MISubstanceReference>
+                            <Name>Lead oxide</Name>
+                        </Substance>
+                    </Substances>
+                </Part>
+                <Part>
+                    <Quantity Unit="Each">1.0</Quantity>
+                    <MassPerUom Unit="kg/Part">2.0</MassPerUom>
+                    <PartNumber />
+                    <Name>Part Two</Name>
+                    <Materials>
+                        <Material>
+                            <Percentage>80.0</Percentage>
+                            <MIMaterialReference>
+                                <gbt:dbKey>MI_Restricted_Substances</gbt:dbKey>
+                                <gbt:recordHistoryGUID>ab4147f6-0e97-47f0-be53-cb5d17dfa82b</gbt:recordHistoryGUID>
+                            </MIMaterialReference>
+                        </Material>
+                    </Materials>
+                </Part>
+            </Components>
+        </Part>
+    </Components>
+    <Notes>
+        <Notes>Part with substance</Notes>
+        <ProductName>Part with substance</ProductName>
+    </Notes>
+    <Annotations>
+        <Text targetId="A0" type="exampleAnnotation">
+            <Value>This is an annotation.</Value>
+        </Text>
+        <Indicator targetId="A0" type="exampleAnnotation">
+            <Value Unit="meters">
+                1.2
+            </Value>
+        </Indicator>
+    </Annotations>
+</PartsEco>


### PR DESCRIPTION
Add an additional argument to BOM load methods `load_bom_from_file` and `load_bom_from_text` to enforce 'strict' deserialization.

The new argument `allow_unsupported_data` defaults to `True`, which follows the current behavior of allowing data which is compliant with the BoM schema, but is not supported by the classes in the `bom_types` submodule.

This is to allow control when downgrading BoMs as part of the 24/12 work. The downgrading will be implemented as a separate method, and that method will also include this argument. In that case though, the unsupported classes will more likely be caused by more modern BoMs that cannot be fully represented in older versions.

The first in a series of three PRs:

1. This PR
2. https://github.com/ansys/grantami-bomanalytics/pull/703
3. https://github.com/ansys/grantami-bomanalytics/pull/693