### PR TITLE
Warm up databases

### DIFF
--- a/doc/changelog.d/708.maintenance.md
+++ b/doc/changelog.d/708.maintenance.md
@@ -1,0 +1,1 @@
+Warm up databases


### PR DESCRIPTION
Closes #705 

Second attempt at making CI more stable, following #706.

This PR replaces the call to BoM Analytics Services with two calls to Server API that depend on the two databases used by this repo. This seemed simpler to write than trying to craft a valid BAS request. I have checked the server while running this script and seen SQL activity, so hopefully this results in improved CI stability.