### PR TITLE
Update jinja2 to 3.1.6

### DIFF
--- a/doc/changelog.d/740.dependencies.md
+++ b/doc/changelog.d/740.dependencies.md
@@ -1,0 +1,1 @@
+Update jinja2 to 3.1.6

--- a/poetry.lock
+++ b/poetry.lock
@@ -1095,14 +1095,14 @@ testing = ["Django", "attrs", "colorama", "docopt", "pytest (<7.0.0)"]
 
 [[package]]
 name = "jinja2"
-version = "3.1.5"
+version = "3.1.6"
 description = "A very fast and expressive template engine."
 optional = false
 python-versions = ">=3.7"
 groups = ["main", "dev", "doc"]
 files = [
-    {file = "jinja2-3.1.5-py3-none-any.whl", hash = "sha256:aba0f4dc9ed8013c424088f68a5c226f7d6097ed89b246d7749c2ec4175c6adb"},
-    {file = "jinja2-3.1.5.tar.gz", hash = "sha256:8fefff8dc3034e27bb80d67c671eb8a9bc424c0ef4c0826edbff304cceff43bb"},
+    {file = "jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67"},
+    {file = "jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d"},
 ]
 
 [package.dependencies]


### PR DESCRIPTION
Update jinja2 to 3.1.6

Addresses https://github.com/ansys/grantami-bomanalytics/security/dependabot/47

Dependabot isn't working with our password-protected dependencies. @da1910 I know you looked at this here https://github.com/ansys/grantami-jobqueue/blob/main/.github/dependabot.yml, did you get any further with figuring out why it doesn't work?