### PR TITLE
Allow dependabot server checks to run in parallel

### DIFF
--- a/.github/workflows/server_checks.yml
+++ b/.github/workflows/server_checks.yml
@@ -63,7 +63,7 @@ env:
   POETRY_HTTP_BASIC_PRIVATE_PYPI_PASSWORD: ${{ secrets.PYANSYS_PYPI_PRIVATE_PAT }}
   
 concurrency:
-  group: integration-server
+  group: integration-server-${{ startsWith( github.event.pull_request.head.ref, 'dependabot/') && github.workflow-github.ref || '' }}
   cancel-in-progress: false
 
 jobs:

--- a/doc/changelog.d/748.maintenance.md
+++ b/doc/changelog.d/748.maintenance.md
@@ -1,0 +1,1 @@
+Allow dependabot server checks to run in parallel


### PR DESCRIPTION
This change should allow dependabot checks to run fully in parallel:

* If the PR HEAD ref starts with 'dependabot/', then include the ref in the concurrency group, to make the group unique.
* If the PR HEAD ref does not start with 'dependabot/', then don't include the ref (existing behavior).

Dependabot doesn't actually run server checks, but they still need to run through this step so we can ensure they were successfully skipped.