### PR TITLE
Move Integration Test check to top-level workflow

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -122,11 +122,21 @@ jobs:
   server-checks:
     name: "Server checks"
     needs: [ smoke-tests ]
+    if: ${{ !startsWith( github.event.pull_request.head.ref, 'dependabot/') }}
     uses: ./.github/workflows/server_checks.yml
     with:
       skip-vm-management: ${{ vars.SKIP_VM_MANAGEMENT == 'true' }}
     secrets:
       inherit
+
+  integration-checks-complete:
+    name: "Integration checks complete"
+    runs-on: ubuntu-latest
+    if: always() && ( startsWith( github.event.pull_request.head.ref, 'dependabot/') || needs.server-checks.result == 'success' )
+    needs: server-checks
+    steps:
+      - name: "Integration checks complete"
+        run: echo "Integration checks complete"
 
   doc-deploy-dev:
     name: "Deploy development documentation"

--- a/.github/workflows/server_checks.yml
+++ b/.github/workflows/server_checks.yml
@@ -71,7 +71,6 @@ jobs:
   start-vm:
     name: "Start Azure VM"
     runs-on: ubuntu-latest
-    if: ${{ !startsWith( github.event.pull_request.head.ref, 'dependabot/') }}
     strategy:
       matrix:
         server:
@@ -115,7 +114,6 @@ jobs:
   integration-tests:
     name: "Integration tests: ${{ matrix.os }}, ${{ matrix.server }}"
     runs-on: ${{ matrix.os }}
-    if: ${{ !startsWith( github.event.pull_request.head.ref, 'dependabot/') }}
     needs: start-vm
     strategy:
       matrix:
@@ -163,7 +161,6 @@ jobs:
   doc-build:
     name: "Build documentation"
     runs-on: ubuntu-latest
-    if: ${{ !startsWith( github.event.pull_request.head.ref, 'dependabot/') }}
     needs: integration-tests
     steps:
       - name: "Run Ansys documentation building action"
@@ -178,26 +175,17 @@ jobs:
           dependencies: "pandoc"
           sphinxopts: "-n -W --keep-going"
 
-  integration-checks-complete:
-    name: "Integration checks complete"
-    runs-on: ubuntu-latest
-    if: always() && (needs.doc-build.result == 'success' || needs.doc-build.result == 'skipped')
-    needs: doc-build
-    steps:
-      - name: "Integration checks complete"
-        run: echo "Integration checks complete"
-
   check-workflow-runs:
     name: Check if there are active workflow runs
     needs: doc-build
     uses: ansys/pygranta/.github/workflows/check-concurrent-workflows.yml@main
-    if: ${{ !cancelled() && !startsWith( github.event.pull_request.head.ref, 'dependabot/') }}
+    if: ${{ !cancelled() }}
 
   stop-vm:
     name: "Stop Azure VM"
     runs-on: ubuntu-latest
     needs: check-workflow-runs
-    if: ${{ !cancelled() && !(inputs.skip-vm-management) && needs.check-workflow-runs.outputs.active-runs != 'true' && !startsWith( github.event.pull_request.head.ref, 'dependabot/') }}
+    if: ${{ !cancelled() && !(inputs.skip-vm-management) && needs.check-workflow-runs.outputs.active-runs != 'true' }}
     strategy:
       matrix:
         server:

--- a/.github/workflows/server_checks.yml
+++ b/.github/workflows/server_checks.yml
@@ -63,7 +63,7 @@ env:
   POETRY_HTTP_BASIC_PRIVATE_PYPI_PASSWORD: ${{ secrets.PYANSYS_PYPI_PRIVATE_PAT }}
   
 concurrency:
-  group: integration-server-${{ startsWith( github.event.pull_request.head.ref, 'dependabot/') && github.workflow-github.ref || '' }}
+  group: integration-server
   cancel-in-progress: false
 
 jobs:

--- a/doc/changelog.d/749.maintenance.md
+++ b/doc/changelog.d/749.maintenance.md
@@ -1,0 +1,1 @@
+Move Integration Test check to top-level workflow


### PR DESCRIPTION
Move Integration Test check to top-level workflow

This should mean that dependabot checks never run the server_checks job, and as a result never encounter the concurrency issue. Instead, include a no-op step outside of server_checks that either validate the checks completed, or that the job was started by dependabot.