### PR TITLE
Add references to 24/12 BoM format in API documentation

### DIFF
--- a/doc/changelog.d/780.documentation.md
+++ b/doc/changelog.d/780.documentation.md
@@ -1,0 +1,1 @@
+Add references to 24/12 BoM format in API documentation

--- a/doc/source/api/bom_builder/index.rst
+++ b/doc/source/api/bom_builder/index.rst
@@ -4,7 +4,7 @@ BoM helpers
 ===========
 
 BoM helpers represent a BoM (bill of materials) in Ansys Granta
-MI 2301 XML BoM format, and they support reading and writing these files.
+MI 23/01 or 24/12 XML BoM format, and they support reading and writing these files.
 
 The :class:`~ansys.grantami.bomanalytics.bom_types.eco2412.BillOfMaterials` represents the root object in a 24/12 BoM
 hierarchy and can be used to programmatically generate a BoM.

--- a/doc/source/api/sustainability/index.rst
+++ b/doc/source/api/sustainability/index.rst
@@ -5,7 +5,7 @@ Sustainability API
 
 The :ref:`ref_grantami_bomanalytics_api_sustainability_bom` and
 :ref:`ref_grantami_bomanalytics_api_sustainability_summary_bom` queries can be used to determine the
-environmental performance of a BoM (bill of materials) in Ansys Granta MI 2301 XML BoM format.
+environmental performance of a BoM (bill of materials) in Ansys Granta MI 23/01 or 24/12 XML BoM format.
 
 The BoM analysis only considers items explicitly defined in the input BoM. It does not follow links
 to other BoM items as in the record-based queries available for Impacted Substances and Compliance


### PR DESCRIPTION
Closes #777 

Add references to the 24/12 BoM format to the BoM Builder and Sustainability API pages. Also use a `/` in the name, which aligns with our usage elsewhere.