### PR TITLE
Use git SHA to pin action version

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -28,7 +28,7 @@ jobs:
     name: "Code style"
     runs-on: ubuntu-latest
     steps:
-      - uses: ansys/actions/code-style@v9
+      - uses: ansys/actions/code-style@2cf9a9c43235a000d613c2b13e64c954232a4553  # v9.0.9
         with:
           skip-install: false
 
@@ -36,7 +36,7 @@ jobs:
     name: "Documentation style"
     runs-on: ubuntu-latest
     steps:
-      - uses: ansys/actions/doc-style@v9
+      - uses: ansys/actions/doc-style@2cf9a9c43235a000d613c2b13e64c954232a4553  # v9.0.9
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: "Run Ansys documentation building action"
-      uses: ansys/actions/doc-build@v9
+      uses: ansys/actions/doc-build@2cf9a9c43235a000d613c2b13e64c954232a4553  # v9.0.9
       with:
         check-links: false
         dependencies: "pandoc"
@@ -53,7 +53,7 @@ jobs:
 
     - name: "Delete unneeded doc artifact"
       if: ${{ !startsWith( github.event.pull_request.head.ref, 'dependabot/') }}
-      uses: geekyeggo/delete-artifact@v5
+      uses: geekyeggo/delete-artifact@f275313e70c08f6120db482d7a6b98377786765b # v5.1.0
       with:
         name: |
           documentation-html
@@ -71,7 +71,7 @@ jobs:
       id-token: write
       attestations: write
     steps:
-      - uses: ansys/actions/build-wheelhouse@v9
+      - uses: ansys/actions/build-wheelhouse@2cf9a9c43235a000d613c2b13e64c954232a4553  # v9.0.9
         with:
           library-name: ${{ env.LIBRARY_NAME }}
           operating-system: ${{ matrix.os }}
@@ -89,10 +89,10 @@ jobs:
       fail-fast: false
     steps:
       - name: "Checkout the repository"
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: "Set up Python ${{ matrix.python-version }}"
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -104,7 +104,7 @@ jobs:
         run: tox -e "tests" -- -m "not integration"
 
       - name: "Upload coverage to Codecov"
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@ad3126e916f78f00edff4ed0317cf185271ccc2d  # v5.4.2
         if: ${{ matrix.python-version == env.MAIN_PYTHON_VERSION && !startsWith( github.event.pull_request.head.ref, 'dependabot/') }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
@@ -121,7 +121,7 @@ jobs:
       id-token: write
       attestations: write
     steps:
-      - uses: ansys/actions/build-library@v9
+      - uses: ansys/actions/build-library@2cf9a9c43235a000d613c2b13e64c954232a4553  # v9.0.9
         with:
           library-name: ${{ env.LIBRARY_NAME }}
           python-version: ${{ env.MAIN_PYTHON_VERSION }}
@@ -152,7 +152,7 @@ jobs:
     needs: [server-checks]
     if: github.event_name == 'push' && !contains(github.ref, 'refs/tags')
     steps:
-      - uses: ansys/actions/doc-deploy-dev@v9
+      - uses: ansys/actions/doc-deploy-dev@2cf9a9c43235a000d613c2b13e64c954232a4553  # v9.0.9
         with:
           cname: ${{ env.DOCUMENTATION_CNAME }}
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -168,7 +168,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: ansys/actions/doc-deploy-changelog@v9
+      - uses: ansys/actions/doc-deploy-changelog@2cf9a9c43235a000d613c2b13e64c954232a4553  # v9.0.9
         with:
           token: ${{ secrets.PYANSYS_CI_BOT_TOKEN }}
           bot-user: ${{ secrets.PYANSYS_CI_BOT_USERNAME }}
@@ -198,7 +198,7 @@ jobs:
           packages-dir: ${{ env.LIBRARY_NAME }}-artifacts
           skip-existing: false
 
-      - uses: ansys/actions/release-github@v9
+      - uses: ansys/actions/release-github@2cf9a9c43235a000d613c2b13e64c954232a4553  # v9.0.9
         name: "Release to GitHub"
         with:
           library-name: ${{ env.LIBRARY_NAME }}
@@ -210,7 +210,7 @@ jobs:
     needs: release
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
     steps:
-      - uses: ansys/actions/doc-deploy-stable@v9
+      - uses: ansys/actions/doc-deploy-stable@2cf9a9c43235a000d613c2b13e64c954232a4553  # v9.0.9
         with:
           cname: ${{ env.DOCUMENTATION_CNAME }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependabot_approve.yml
+++ b/.github/workflows/dependabot_approve.yml
@@ -8,7 +8,7 @@ jobs:
     # Checking the author will prevent your Action run failing on non-Dependabot PRs
     if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.user.login == 'pre-commit-ci[bot]' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       - name: Approve a PR if not already approved
         run: |
           gh pr checkout "$PR_URL" # sets the upstream metadata for `gh pr status`

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -17,8 +17,8 @@ jobs:
     name: Syncer
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: micnncim/action-label-syncer@v1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: micnncim/action-label-syncer@3abd5ab72fda571e69fffd97bd4e0033dd5f495c  # v1.3.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -31,7 +31,7 @@ jobs:
     if: github.event_name == 'pull_request'
     steps:
     - name: Label based on changed files and branch names
-      uses: actions/labeler@v5
+      uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9  #v5.0.0
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Suggest to add labels
-      uses: peter-evans/create-or-update-comment@v4
+      uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043  #v4.0.0
       # Execute only when no labels have been applied to the pull request
       if: toJSON(github.event.pull_request.labels.*.name) == '{}'
       with:
@@ -60,7 +60,7 @@ jobs:
       runs-on: ubuntu-latest
       if: ${{ !startsWith( github.event.pull_request.head.ref, 'dependabot/') && !(startsWith(github.event.pull_request.head.ref, 'pre-commit-ci-update-config')) }}
       steps:
-      - uses: ansys/actions/doc-changelog@v9
+      - uses: ansys/actions/doc-changelog@2cf9a9c43235a000d613c2b13e64c954232a4553  # v9.0.9
         with:
           token: ${{ secrets.PYANSYS_CI_BOT_TOKEN }}
           bot-user: ${{ secrets.PYANSYS_CI_BOT_USERNAME }}

--- a/.github/workflows/server_checks.yml
+++ b/.github/workflows/server_checks.yml
@@ -82,11 +82,11 @@ jobs:
             url: "TEST_SERVER_24R2_URL"
     steps:
       - name: "Checkout the repository"
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: "Start VM with Azure CLI"
         id: azure_cli
-        uses: azure/CLI@v2
+        uses: azure/CLI@089eac9d8cc39f5d003e94f8b65efc51076c9cbd  #v2.1.0
         if:   ${{ !(inputs.skip-vm-management)}}
         with:
           azcliversion: 2.32.0
@@ -95,7 +95,7 @@ jobs:
             az vm start -g ${{ secrets.AZURE_RESOURCE_GROUP }} -n ${{ secrets[matrix.server.name] }}
 
       - name: "Set up Python ${{ inputs.python-version }}"
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: ${{ inputs.python-version }}
 
@@ -129,10 +129,10 @@ jobs:
       cancel-in-progress: false
     steps:
       - name: "Checkout the repository"
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: "Set up Python ${{ inputs.python-version }}"
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: ${{ inputs.python-version }}
 
@@ -150,7 +150,7 @@ jobs:
           TEST_WRITE_PASS: ${{secrets.TEST_SERVER_WRITE_PASS}}
 
       - name: "Upload coverage to Codecov"
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@ad3126e916f78f00edff4ed0317cf185271ccc2d  # v5.4.2
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -164,7 +164,7 @@ jobs:
     needs: integration-tests
     steps:
       - name: "Run Ansys documentation building action"
-        uses: ansys/actions/doc-build@v9
+        uses: ansys/actions/doc-build@2cf9a9c43235a000d613c2b13e64c954232a4553  # v9.0.9
         env:
           TEST_SL_URL: ${{secrets.TEST_SERVER_DEV_URL}}
           TEST_USER: ${{secrets.TEST_SERVER_READ_USER}}
@@ -194,7 +194,7 @@ jobs:
           - "AZURE_VM_NAME_24R2"
           - "AZURE_VM_NAME_24R1"
     steps:
-      - uses: azure/CLI@v2
+      - uses: azure/CLI@089eac9d8cc39f5d003e94f8b65efc51076c9cbd  #v2.1.0
         with:
           azcliversion: 2.32.0
           inlineScript: |

--- a/doc/changelog.d/785.maintenance.md
+++ b/doc/changelog.d/785.maintenance.md
@@ -1,0 +1,1 @@
+Use git SHA to pin action version


### PR DESCRIPTION
Closes #784 

All actions are pinned to the latest available version, except for ansys/actions which are pinned to v9.0.9. See https://github.com/ansys/actions/issues/814 for cause.