### PR TITLE
Shutdown 2025R2 machine

### DIFF
--- a/.github/workflows/server_checks.yml
+++ b/.github/workflows/server_checks.yml
@@ -28,6 +28,8 @@ on:
       # Test server names
       AZURE_VM_NAME_DEV:
         required: true
+      AZURE_VM_NAME_25R2:
+        required: true
       AZURE_VM_NAME_25R1:
         required: true
       AZURE_VM_NAME_24R2:
@@ -190,6 +192,7 @@ jobs:
       matrix:
         server:
           - "AZURE_VM_NAME_DEV"
+          - "AZURE_VM_NAME_25R2"
           - "AZURE_VM_NAME_25R1"
           - "AZURE_VM_NAME_24R2"
           - "AZURE_VM_NAME_24R1"


### PR DESCRIPTION
Whilst main currently does not start the 2025 R2 release machine, it may be running when main CI starts. We need to try and shut it down in case it is running.