### PR TITLE
Fix version number on main branch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.core.masonry.api"
 [tool.poetry]
 name = "ansys-grantami-bomanalytics"
 description = "Perform compliance and sustainability analysis on materials data stored in Granta MI."
-version = "2.4.0dev0"
+version = "2.4.0.dev0"
 license = "MIT"
 authors = ["ANSYS, Inc. <pyansys.core@ansys.com>"]
 maintainers = ["ANSYS, Inc. <pyansys.core@ansys.com>"]


### PR DESCRIPTION
Python version numbering requires a . before a dev version number to ensure it is applied correctly. As currently written, pip may incorrectly resolve the latest version when comparing this version to a future alpha, beta, rc, or final release.