### PR TITLE
Add a plot to test examples

### DIFF
--- a/examples-dummy/examples/1_Test_Example/1-1_Test_other_features.py
+++ b/examples-dummy/examples/1_Test_Example/1-1_Test_other_features.py
@@ -44,3 +44,21 @@ import numpy as np
 df = pd.DataFrame(np.random.rand(10, 10))
 df.head()
 # -
+
+# +
+import plotly.express as px
+
+data = {
+    "color": ["Blue", "Red", "Green", "Purple"],
+    "parent": ["Purple", "Purple", "", ""],
+    "value": [7, 3, 2.5, 0],
+}
+
+fig = px.sunburst(
+    data,
+    names="color",
+    parents="parent",
+    values="value",
+)
+fig.show()
+# -


### PR DESCRIPTION
Add a simple interactive plotly graph to the dummy examples. This should allow us to validate that plotly is generated the code we expect without running integration tests.