### PR TITLE
Add an example of creating a BoM from a CSV file

### DIFF
--- a/doc/changelog.d/819.documentation.md
+++ b/doc/changelog.d/819.documentation.md
@@ -1,1 +1,0 @@
-Add an example of creating a BoM from a CSV file

--- a/doc/changelog.d/819.documentation.md
+++ b/doc/changelog.d/819.documentation.md
@@ -1,0 +1,1 @@
+Add an example of creating a BoM from a CSV file

--- a/doc/changelog.d/819.miscellaneous.md
+++ b/doc/changelog.d/819.miscellaneous.md
@@ -1,0 +1,1 @@
+Add an example of creating a bom from a csv file

--- a/examples/6_BoMs/6-3_Creating_an_XML_BoM_from_CSV.py
+++ b/examples/6_BoMs/6-3_Creating_an_XML_BoM_from_CSV.py
@@ -15,8 +15,8 @@
 
 # # Create an XML BoM from a CSV data source
 
-# This example shows how to use the ``bom_types`` subpackage to create a valid Granta MI XML
-# BoM. This subpackage can be used to help construct a Granta 24/12-compliant XML BoM file to
+# This example shows how to use the ``bom_types`` subpackage to create a Granta MI BoM.
+# This subpackage can be used to help construct a Granta 24/12-compliant XML BoM file to
 # use with the BoM queries provided by this package. The code in this example shows how to generate
 # a BoM from a representative CSV data source. The general approach can be applied to data
 # in other formats or provided by other APIs.
@@ -45,22 +45,23 @@ df.head()
 # machine screws (DIN-7991-M8-20) and washers (N0403.12N.2). The door glass (321-51) is coated with a partially
 # reflective polymer film (7000001298).
 #
-# The hierarchy of items within the BoM is defined by the order of items in the CSV and the ``BoM Level`` field. If an
+# The hierarchy of items within the BoM is defined by the order of items in the CSV and the ``BoM Level`` column. If an
 # item has the BoM level *n*, then the item's parent is the first level preceding it in the CSV with a BoM level *n-1*.
 #
-# Each item includes an ``Item Type`` field that identifies the type of the item, here only ``Part`` or ``Material``.
-# Additional fields are specific to the type of item.
+# Each item includes an ``Item Type`` column that identifies the type of the item, in this example the only values are
+# ``Part`` or ``Material``.
+# Additional columns are specific to the type of item.
 #
 # ### Part items
 #
 # Items that refer to parts only exist in the BoM and do not reference records in Granta MI. Their ``Name`` and ``ID``
 # are defined only in the BoM to identify parts.
 #
-# The ``Quantity`` and ``Unit of measure`` fields describe the quantity of part expected in the parent. This can be
+# The ``Quantity`` and ``Unit of measure`` columns describe the quantity of part expected in the parent. This can be
 # done by specifying how many occurrences of a part are in an assembly, or for example for the glass door, the surface
 # area of laminated glass.
 #
-# There are three types of components in the BoM:
+# There are three types of components in this example BoM:
 #
 #  - The product described by the BoM, whose ``BoM Level`` is ``1``.
 #  - Assemblies which are made of sub-parts.
@@ -78,9 +79,9 @@ df.head()
 # ### Material items
 #
 # Items that refer to materials correspond to records in Granta MI that contain the relevant compliance or
-# sustainability information for these items. As a result, these items contain both a human-readable ``Name`` field and
-# an ``ID`` field. In this scenario, the system that provided the data source contains the Granta MI material
-# assignments for each part based on the ``Material ID`` attribute, which is included in the ``ID`` field.
+# sustainability information for these items. As a result, these items include both a human-readable ``Name`` column and
+# an ``ID`` column. In this scenario, the system that provided the data source contains the Granta MI material
+# assignments for each part based on the ``Material ID`` attribute, which is included in the ``ID`` column.
 #
 # Materials are described in terms of percentage of the parent part made of the material.
 

--- a/examples/6_BoMs/6-3_Creating_an_XML_BoM_from_CSV.py
+++ b/examples/6_BoMs/6-3_Creating_an_XML_BoM_from_CSV.py
@@ -15,16 +15,16 @@
 
 # # Create an XML BoM from a CSV data source
 
-# ## This example shows how to use the ``bom_types`` subpackage to create a valid Granta MI XML
+# This example shows how to use the ``bom_types`` subpackage to create a valid Granta MI XML
 # BoM. This subpackage can be used to help construct a Granta 24/12-compliant XML BoM file to
 # use with the BoM queries provided by this package. The code in this example shows how to generate
 # a BoM from a representative CSV data source. The general approach can be applied to data
 # in other formats or provided by other APIs.
 
-# You can download the [csv file](../supporting-files/glass_door.csv) used in this example.
+# You can download the [CSV file](../supporting-files/glass_door.csv) used in this example.
 
 # The result of this example is a Granta 24/12-compliant XML BoM file that is suitable for
-# compliance analysis with the Granta MI BoM Analytics API. For more information on the
+# compliance or sustainability analysis with the Granta MI BoM Analytics API. For more information on the
 # expected content of XML BoMs, see the Granta MI documentation.
 
 # ## Load the external data
@@ -32,73 +32,74 @@
 # First load the CSV file and use ``pandas`` to load the content in a dataframe.
 
 # +
-import pandas
+import pandas as pd
 
-df = pandas.read_csv("../supporting-files/glass_door.csv")
+df = pd.read_csv("../supporting-files/glass_door.csv")
 df.head()
+# -
 
-# + [markdown] jp-MarkdownHeadingCollapsed=true
 # ## Inspect the external data
-# The external data source defines a flat list of items.
+# The CSV file describes the bill of materials for the door assembly introduced in the
+# [Creating an XML BoM](./6-1_Creating_an_XML_BoM.ipynb) example.
+# The door (24X6-30) contains two hinges (HA-42-Al) and a handle (H-S-BR-Dual), both fixed to the panel (P-30-L) with
+# machine screws (DIN-7991-M8-20) and washers (N0403.12N.2). The door glass (321-51) is coated with a partially
+# reflective polymer film (7000001298).
 #
-# Hierarchy of items within the BoM is defined by the order of items in the list and the ``BoM Level`` field.
+# The hierarchy of items within the BoM is defined by the order of items in the CSV and the ``BoM Level`` field. If an
+# item has the BoM level *n*, then the item's parent is the first level preceding it in the CSV with a BoM level *n-1*.
 #
-# Each item has at least the following:
+# Each item includes an ``Item Type`` field that identifies the type of the item, here only ``Part`` or ``Material``.
+# Additional fields are specific to the type of item.
 #
-# - A ``Item Type`` field that identifies the type of the item.
-# - ``Quantity`` and ``Unit of measure`` fields that describe the quantity of the item. Typically, materials are
-#   described in terms of percentage of the parent part made of the material, and components are described in terms of
-#   number of occurrences of the part in the parent part.
+# ### Part items
 #
-# ### Components
+# Items that refer to parts only exist in the BoM and do not reference records in Granta MI. Their ``Name`` and ``ID``
+# are defined only in the BoM to identify parts.
 #
-# Items that refer to components do not have an equivalent record in Granta MI. Their names and ID are defined only in
-# the BoM.
+# The ``Quantity`` and ``Unit of measure`` fields describe the quantity of part expected in the parent. This can be
+# done by specifying how many occurrences of a part are in an assembly, or for example for the glass door, the surface
+# area of laminated glass.
 #
 # There are three types of components in the BoM:
 #
 #  - The product described by the BoM, whose ``BoM Level`` is ``1``.
 #  - Assemblies which are made of sub-parts.
+#    - Their mass isn't defined in the BoM because it can be computed by rolling up the mass of the sub-parts.
 #  - Parts which are defined by their mass and the material they are made of.
-#
-# ### Materials
-#
-# Items that refer to materials correspond to records in Granta MI that contain the relevant compliance information
-# for these items. As a result, these items contain both a human-readable ``Name`` field and a ``ID`` field. In this
-# scenario, the system that provided the data source contains the direct material assignments from
-# Granta MI and the ``ID`` fields contains the value of the ``Material ID`` attribute for the material records.
-# -
-
-# ## Build the ``BillsOfMaterials`` object
-#
-# Instantiate a ``BillsOfMaterials`` object. It will be populated with content as the content of the csv is processed.
-
-# +
-from ansys.grantami.bomanalytics.bom_types import eco2412, gbt1205
-
-DB_KEY = "MI_Restricted_Substances"
-TABLE_NAME = "MaterialUniverse"
-
-bom = eco2412.BillOfMaterials(components=[])
-
-
-# -
-
-# Define a method to process a row that represents a part and create the appropriate object.
-#
-# In this example, parts are specified in two different ways:
-#
-#  - Via non-mass units. For example ``HA-42-Al`` is included twice in its parent ``24X6-30``, and its mass is defined
-#    as mass per occurrence of the part.
-#  - Via mass units. For example ``321-51`` is present in the BoM and specified as a surface area. Its mass is
-#    therefore defined as a mass per surface area.
+#    - Their mass is defined via the ``Measured mass (per UoM)`` and ``Measured mass unit``. The units for the mass
+#       must be consistent with the unit used to define the quantity of the part, so that when the quantity is
+#       multiplied with the mass per UoM, it resolves to a mass. For example, the quantity of glass panel included in
+#       the door is defined as a surface area ``1.51 m^2``, which requires the mass per unit of measure to be defined
+#       as a mass per surface area ``19.6 kg/m^2``.
 #
 # For more information on the different options available for specifying part quantities and part masses, see the
 # Granta MI documentation.
+#
+# ### Material items
+#
+# Items that refer to materials correspond to records in Granta MI that contain the relevant compliance or
+# sustainability information for these items. As a result, these items contain both a human-readable ``Name`` field and
+# an ``ID`` field. In this scenario, the system that provided the data source contains the Granta MI material
+# assignments for each part based on the ``Material ID`` attribute, which is included in the ``ID`` field.
+#
+# Materials are described in terms of percentage of the parent part made of the material.
 
-def make_part(item: pandas.Series) -> eco2412.Part:
+# ## Build the ``BillsOfMaterials`` object
+#
+# Import the ``eco2412`` sub-package and helper classes to build record and attribute references.
+
+# +
+from ansys.grantami.bomanalytics.bom_types import eco2412, AttributeReferenceBuilder, RecordReferenceBuilder
+
+DB_KEY = "MI_Restricted_Substances"
+TABLE_NAME = "MaterialUniverse"
+# -
+
+# Define a function that accepts a part row as input and returns a ``eco2412.Part`` object.
+
+def make_part(item: pd.Series) -> eco2412.Part:
     mass = item["Measured mass (per UoM)"]
-    if not pandas.isna(mass):
+    if not pd.isna(mass):
         mass_per_unit_of_measure = eco2412.UnittedValue(
             value=mass,
             unit=item["Measured mass unit"],
@@ -112,28 +113,31 @@ def make_part(item: pandas.Series) -> eco2412.Part:
         mass_per_unit_of_measure=mass_per_unit_of_measure,
     )
 
-# Define a method to process a row that represents a material and instantiate a ``eco2412.Material``. Materials are
+# Define a function that accepts a material row as input and returns a ``eco2412.Material`` object. Materials are
 # identified by their attribute value ``Material ID``, so the record reference is defined using a lookup value.
 
 # +
-material_id_reference = gbt1205.MIAttributeReference(
-    db_key=DB_KEY,
-    table_reference=gbt1205.PartialTableReference(table_name=TABLE_NAME),
-    attribute_name="Material ID",
+material_id_reference = (
+    AttributeReferenceBuilder(DB_KEY)
+    .with_attribute_name("Material ID")
+    .with_table_name(TABLE_NAME)
+    .build()
 )
 
-def make_material(item: pandas.Series) -> eco2412.Material:
+def make_material(item: pd.Series) -> eco2412.Material:
     unit = item["Unit of measure"]
     if unit == "%":
         percentage = item["Quantity"]
     else:
         raise ValueError("Method 'make_material' only supports quantities defined as percentages.")
+
+    material_reference = (
+        RecordReferenceBuilder(db_key=DB_KEY)
+        .with_lookup_value(lookup_value=item["ID"], lookup_attribute_reference=material_id_reference)
+        .build()
+    )
     return eco2412.Material(
-        mi_material_reference=gbt1205.MIRecordReference(
-            db_key=DB_KEY,
-            lookup_attribute_reference=material_id_reference,
-            lookup_value=item["ID"]
-        ),
+        mi_material_reference=material_reference,
         identity=item["ID"],
         name=item["Name"],
         percentage=percentage,
@@ -145,8 +149,10 @@ def make_material(item: pandas.Series) -> eco2412.Material:
 # Iterate over the rows in the CSV file and convert to ``bom_types`` objects. Because items only ever appear after
 # their parent, a list is used to keep track of possible parent items in the BoM.
 
-# Instantiate the hierarchy with the empty BoM object
+# Instantiate the hierarchy with an empty BoM object
+bom = eco2412.BillOfMaterials(components=[])
 path = [bom]
+
 for _, item_row in df.iterrows():
     item_level = item_row["BoM Level"]
     parent = path[item_level - 1]
@@ -167,8 +173,7 @@ for _, item_row in df.iterrows():
 # ## Serialize the BoM
 #
 # Use the ``BomHandler`` helper class to serialize the object to XML. The resulting string can be
-# used in a compliance query. For more information, see the
-# [Compliance examples](../3_Compliance_Queries/index.rst).
+# used in a BoM query.
 
 from ansys.grantami.bomanalytics import BoMHandler
 bom_as_xml = BoMHandler().dump_bom(bom)

--- a/examples/6_BoMs/6-3_Creating_an_XML_BoM_from_CSV.py
+++ b/examples/6_BoMs/6-3_Creating_an_XML_BoM_from_CSV.py
@@ -46,9 +46,9 @@ df.head()
 # Each item has at least the following:
 #
 # - A ``Item Type`` field that identifies the type of the item.
-# - ``Quantity`` and ``Unit of measure`` fields that describe the quantity of the item. Typically, materials are described
-#   in terms of percentage of the parent part made of the material, and components are described in terms of number of
-#   occurrences of the part in the parent part.
+# - ``Quantity`` and ``Unit of measure`` fields that describe the quantity of the item. Typically, materials are
+#   described in terms of percentage of the parent part made of the material, and components are described in terms of
+#   number of occurrences of the part in the parent part.
 #
 # ### Components
 #
@@ -56,7 +56,7 @@ df.head()
 # the BoM.
 #
 # There are three types of components in the BoM:
-#  
+#
 #  - The product described by the BoM, whose ``BoM Level`` is ``1``.
 #  - Assemblies which are made of sub-parts.
 #  - Parts which are defined by their mass and the material they are made of.
@@ -86,12 +86,15 @@ bom = eco2412.BillOfMaterials(components=[])
 
 # Define a method to process a row that represents a part and create the appropriate object.
 #
-# In this example, parts are specified in two differents ways:
+# In this example, parts are specified in two different ways:
 #
-#  - Via non-mass units. For example ``HA-42-Al`` is included twice in its parent ``24X6-30``, and its mass is defined as mass per occurence of the part.
-#  - Via mass units. For example ``321-51`` is present in the BoM and specified as a surface area. Its mass is therefore defined as a mass per surface area.
+#  - Via non-mass units. For example ``HA-42-Al`` is included twice in its parent ``24X6-30``, and its mass is defined
+#    as mass per occurrence of the part.
+#  - Via mass units. For example ``321-51`` is present in the BoM and specified as a surface area. Its mass is
+#    therefore defined as a mass per surface area.
 #
-# For more information on the different options available for specifying part quantities and part masses, see the Granta MI documentation.
+# For more information on the different options available for specifying part quantities and part masses, see the
+# Granta MI documentation.
 
 def make_part(item: pandas.Series) -> eco2412.Part:
     mass = item["Measured mass (per UoM)"]
@@ -109,7 +112,8 @@ def make_part(item: pandas.Series) -> eco2412.Part:
         mass_per_unit_of_measure=mass_per_unit_of_measure,
     )
 
-# Define a method to process a row that represents a material and instantiate a ``eco2412.Material``. Materials are identified by their attribute value ``Material ID``, so the record reference is defined using a lookup value.
+# Define a method to process a row that represents a material and instantiate a ``eco2412.Material``. Materials are
+# identified by their attribute value ``Material ID``, so the record reference is defined using a lookup value.
 
 # +
 material_id_reference = gbt1205.MIAttributeReference(
@@ -138,7 +142,8 @@ def make_material(item: pandas.Series) -> eco2412.Material:
 
 # -
 
-# Iterate over the rows in the CSV file and convert to ``bom_types`` objects. Because items only ever appear after their parent, a list is used to keep track of possible parent items in the BoM.
+# Iterate over the rows in the CSV file and convert to ``bom_types`` objects. Because items only ever appear after
+# their parent, a list is used to keep track of possible parent items in the BoM.
 
 # Instantiate the hierarchy with the empty BoM object
 path = [bom]
@@ -155,7 +160,7 @@ for _, item_row in df.iterrows():
         parent.materials.append(item)
     else:
         raise ValueError(f"Unsupported 'Item Type': '{item_type}'")
-        
+
     # Update the hierarchy with the newly created item
     path = path[:item_level] + [item]
 

--- a/examples/6_BoMs/6-3_Creating_an_XML_BoM_from_CSV.py
+++ b/examples/6_BoMs/6-3_Creating_an_XML_BoM_from_CSV.py
@@ -1,0 +1,170 @@
+# ---
+# jupyter:
+#   jupytext:
+#     formats: ipynb,py:light
+#     text_representation:
+#       extension: .py
+#       format_name: light
+#       format_version: '1.5'
+#       jupytext_version: 1.17.2
+#   kernelspec:
+#     display_name: Python 3 (ipykernel)
+#     language: python
+#     name: python3
+# ---
+
+# # Create an XML BoM from a CSV data source
+
+# ## This example shows how to use the ``bom_types`` subpackage to create a valid Granta MI XML
+# BoM. This subpackage can be used to help construct a Granta 24/12-compliant XML BoM file to
+# use with the BoM queries provided by this package. The code in this example shows how to generate
+# a BoM from a representative CSV data source. The general approach can be applied to data
+# in other formats or provided by other APIs.
+
+# You can download the [csv file](../supporting-files/glass_door.csv) used in this example.
+
+# The result of this example is a Granta 24/12-compliant XML BoM file that is suitable for
+# compliance analysis with the Granta MI BoM Analytics API. For more information on the
+# expected content of XML BoMs, see the Granta MI documentation.
+
+# ## Load the external data
+
+# First load the CSV file and use ``pandas`` to load the content in a dataframe.
+
+# +
+import pandas
+
+df = pandas.read_csv("../supporting-files/glass_door.csv")
+df.head()
+
+# + [markdown] jp-MarkdownHeadingCollapsed=true
+# ## Inspect the external data
+# The external data source defines a flat list of items.
+#
+# Hierarchy of items within the BoM is defined by the order of items in the list and the ``BoM Level`` field.
+#
+# Each item has at least the following:
+#
+# - A ``Item Type`` field that identifies the type of the item.
+# - ``Quantity`` and ``Unit of measure`` fields that describe the quantity of the item. Typically, materials are described
+#   in terms of percentage of the parent part made of the material, and components are described in terms of number of
+#   occurrences of the part in the parent part.
+#
+# ### Components
+#
+# Items that refer to components do not have an equivalent record in Granta MI. Their names and ID are defined only in
+# the BoM.
+#
+# There are three types of components in the BoM:
+#  
+#  - The product described by the BoM, whose ``BoM Level`` is ``1``.
+#  - Assemblies which are made of sub-parts.
+#  - Parts which are defined by their mass and the material they are made of.
+#
+# ### Materials
+#
+# Items that refer to materials correspond to records in Granta MI that contain the relevant compliance information
+# for these items. As a result, these items contain both a human-readable ``Name`` field and a ``ID`` field. In this
+# scenario, the system that provided the data source contains the direct material assignments from
+# Granta MI and the ``ID`` fields contains the value of the ``Material ID`` attribute for the material records.
+# -
+
+# ## Build the ``BillsOfMaterials`` object
+#
+# Instantiate a ``BillsOfMaterials`` object. It will be populated with content as the content of the csv is processed.
+
+# +
+from ansys.grantami.bomanalytics.bom_types import eco2412, gbt1205
+
+DB_KEY = "MI_Restricted_Substances"
+TABLE_NAME = "MaterialUniverse"
+
+bom = eco2412.BillOfMaterials(components=[])
+
+
+# -
+
+# Define a method to process a row that represents a part and create the appropriate object.
+#
+# In this example, parts are specified in two differents ways:
+#
+#  - Via non-mass units. For example ``HA-42-Al`` is included twice in its parent ``24X6-30``, and its mass is defined as mass per occurence of the part.
+#  - Via mass units. For example ``321-51`` is present in the BoM and specified as a surface area. Its mass is therefore defined as a mass per surface area.
+#
+# For more information on the different options available for specifying part quantities and part masses, see the Granta MI documentation.
+
+def make_part(item: pandas.Series) -> eco2412.Part:
+    mass = item["Measured mass (per UoM)"]
+    if not pandas.isna(mass):
+        mass_per_unit_of_measure = eco2412.UnittedValue(
+            value=mass,
+            unit=item["Measured mass unit"],
+        )
+    else:
+        mass_per_unit_of_measure = None
+    return eco2412.Part(
+        part_number=item["ID"],
+        part_name=item["Name"],
+        quantity=eco2412.UnittedValue(value=item["Quantity"], unit=item["Unit of measure"]),
+        mass_per_unit_of_measure=mass_per_unit_of_measure,
+    )
+
+# Define a method to process a row that represents a material and instantiate a ``eco2412.Material``. Materials are identified by their attribute value ``Material ID``, so the record reference is defined using a lookup value.
+
+# +
+material_id_reference = gbt1205.MIAttributeReference(
+    db_key=DB_KEY,
+    table_reference=gbt1205.PartialTableReference(table_name=TABLE_NAME),
+    attribute_name="Material ID",
+)
+
+def make_material(item: pandas.Series) -> eco2412.Material:
+    unit = item["Unit of measure"]
+    if unit == "%":
+        percentage = item["Quantity"]
+    else:
+        raise ValueError("Method 'make_material' only supports quantities defined as percentages.")
+    return eco2412.Material(
+        mi_material_reference=gbt1205.MIRecordReference(
+            db_key=DB_KEY,
+            lookup_attribute_reference=material_id_reference,
+            lookup_value=item["ID"]
+        ),
+        identity=item["ID"],
+        name=item["Name"],
+        percentage=percentage,
+    )
+
+
+# -
+
+# Iterate over the rows in the CSV file and convert to ``bom_types`` objects. Because items only ever appear after their parent, a list is used to keep track of possible parent items in the BoM.
+
+# Instantiate the hierarchy with the empty BoM object
+path = [bom]
+for _, item_row in df.iterrows():
+    item_level = item_row["BoM Level"]
+    parent = path[item_level - 1]
+
+    item_type = item_row["Item Type"]
+    if item_type == "Part":
+        item = make_part(item_row)
+        parent.components.append(item)
+    elif item_type == "Material":
+        item = make_material(item_row)
+        parent.materials.append(item)
+    else:
+        raise ValueError(f"Unsupported 'Item Type': '{item_type}'")
+        
+    # Update the hierarchy with the newly created item
+    path = path[:item_level] + [item]
+
+# ## Serialize the BoM
+#
+# Use the ``BomHandler`` helper class to serialize the object to XML. The resulting string can be
+# used in a compliance query. For more information, see the
+# [Compliance examples](../3_Compliance_Queries/index.rst).
+
+from ansys.grantami.bomanalytics import BoMHandler
+bom_as_xml = BoMHandler().dump_bom(bom)
+print(f"{bom_as_xml[:500]}...")

--- a/examples/6_BoMs/index.rst
+++ b/examples/6_BoMs/index.rst
@@ -10,3 +10,4 @@ These examples demonstrate how to create XML BoMs.
 
    6-1_Creating_an_XML_BoM
    6-2_Creating_an_XML_BoM_from_JSON
+   6-3_Creating_an_XML_BoM_from_CSV

--- a/examples/supporting-files/glass_door.csv
+++ b/examples/supporting-files/glass_door.csv
@@ -1,0 +1,27 @@
+﻿BoM Level,ID,Name,Item Type,Quantity,Unit of measure,Measured mass (per UoM),Measured mass unit
+1,24X6-30,24X6-30,Part,1,Each,,
+2,HA-42-Al,HA-42-Al,Part,2,Each,,
+3,HA-42-Al(A),HA-42-Al(A),Part,1,Each,146,g/Part
+4,aluminum-319-0-moldcast-t6,"Aluminum, 319.0, permanent mold cast, T6",Material,100,%,,
+3,HA-42-Al(B),HA-42-Al(B),Part,1,Each,220,g/Part
+4,aluminum-319-0-moldcast-t6,"Aluminum, 319.0, permanent mold cast, T6",Material,100,%,,
+3,N0403.12N.2,N0403.12N.2,Part,4,Each,2,g/Part
+4,plastic-pa6-cast-plasticized,"PA6 (cast, plasticized)",Material,100,%,,
+3,DIN-7991-M8-20,DIN-7991-M8-20,Part,2,Each,8.6,g/Part
+4,stainless-304-halfhard,"Stainless steel, austenitic, AISI 304, 1/2 hard",Material,100,%,,
+2,H-S-BR-Dual,H-S-BR-Dual,Part,1,Each,,
+3,H-S-BR-A,H-S-BR-A,Part,1,Each,472,g/Part
+4,stainless-304-annealed,"Stainless steel, austenitic, AISI 304, annealed",Material,100,%,,
+3,H-S-BR-B,H-S-BR-B,Part,1,Each,464,g/Part
+4,stainless-304-annealed,"Stainless steel, austenitic, AISI 304, annealed",Material,100,%,,
+3,H-PIN-12,H-PIN-12,Part,2,Each,46.5,g/Part
+4,steel-1015-normalized,"Carbon steel, AISI 1015, normalized",Material,100,%,,
+3,N0403.12N.2,N0403.12N.2,Part,4,Each,2,g/Part
+4,plastic-pa6-cast-plasticized,"PA6 (cast, plasticized)",Material,100,%,,
+3,SSF-M4-6-A2,SSF-M4-6-A2,Part,2,Each,1.3,g/Part
+4,stainless-304-halfhard,"Stainless steel, austenitic, AISI 304, 1/2 hard",Material,100,%,,
+2,P-30-L,P-30-L,Part,1,Each,,
+3,321-51,321-51,Part,1.51,m^2,19.6,kg/m^2
+4,glass-laminated,Laminated glass,Material,100,%,,
+3,7000001298,7000001298,Part,1.51,m^2,340,g/m^2
+4,plastic-pet,"PET (unfilled, amorphous)",Material,100,%,,


### PR DESCRIPTION
Close #733 

Add example of processing a CSV file into a BoM.
CSV format matches the output of BoMAnalyzer reports: sequential traversal of the bom, no direct reference to the parent, but a value that represents the level in the BoM.