### PR TITLE
Refer to the documentation on Ansys Help that relates to the 2025 R2 release

### DIFF
--- a/doc/changelog.d/855.miscellaneous.md
+++ b/doc/changelog.d/855.miscellaneous.md
@@ -1,0 +1,1 @@
+Refer to 2025 r2 ansys help

--- a/doc/changelog.d/855.miscellaneous.md
+++ b/doc/changelog.d/855.miscellaneous.md
@@ -1,1 +1,1 @@
-Refer to 2025 r2 ansys help
+Refer to the documentation on ansys help that relates to the 2025 r2 release

--- a/doc/source/api/compliance/bom.rst
+++ b/doc/source/api/compliance/bom.rst
@@ -4,8 +4,8 @@ BoM compliance
 ==============
 
 For more information about BoM item types relevant for compliance analysis, see
-:MI_docs:`BoM item types for Restricted Substances <rs_and_sustainability/bom_items_rs.html>`
-in the Granta MI product documentation.
+:MI_docs:`Item types for Restricted Substances <one_mi/bom_items_rs.html>` in the
+Granta MI product documentation.
 
 For some important restrictions on BoM-based queries, see
 :ref:`ref_grantami_bomanalytics_bom_query_restrictions`.

--- a/doc/source/api/compliance/indicators.rst
+++ b/doc/source/api/compliance/indicators.rst
@@ -12,9 +12,8 @@ Indicators can include a list of legislations, in which case a substance is impa
 impacted by one or more legislations included in that indicator.
 
 There are two different types of indicator, and they compute compliance in slightly different ways. It is therefore
-important to understand the differences between them. For more information, see the
-:MI_docs:`Restricted Substances Reports User Guide <one_mi/restricted_substances.html>` supplied with
-Granta MI Restricted Substances Reports.
+important to understand the differences between them. For more information, see
+:MI_docs:`Compliance indicators <one_mi/compliance_indicators.html>` in the Granta MI product documentation.
 
 
 RoHS indicator

--- a/doc/source/api/compliance/indicators.rst
+++ b/doc/source/api/compliance/indicators.rst
@@ -13,7 +13,7 @@ impacted by one or more legislations included in that indicator.
 
 There are two different types of indicator, and they compute compliance in slightly different ways. It is therefore
 important to understand the differences between them. For more information, see the
-:MI_docs:`Restricted Substances Reports User Guide <rs_and_sustainability/restricted_substances.html>` supplied with
+:MI_docs:`Restricted Substances Reports User Guide <one_mi/restricted_substances.html>` supplied with
 Granta MI Restricted Substances Reports.
 
 

--- a/doc/source/api/impacted_substances/bom.rst
+++ b/doc/source/api/impacted_substances/bom.rst
@@ -4,7 +4,7 @@ BoM impacted substances
 =======================
 
 For more information about BoM item types relevant for impacted substances analysis, refer to the
-:MI_docs:`BoM item types for Restricted Substances <rs_and_sustainability/bom_items_rs.html>` section of the online
+:MI_docs:`Item types for Restricted Substances <one_mi/bom_items_rs.html>` section of the online
 documentation.
 
 Consult :ref:`ref_grantami_bomanalytics_bom_query_restrictions` for some important restrictions on

--- a/doc/source/api/sustainability/index.rst
+++ b/doc/source/api/sustainability/index.rst
@@ -12,8 +12,8 @@ to other BoM items as in the record-based queries available for Impacted Substan
 analysis.
 
 For more information about BoM item types relevant for sustainability analysis, see
-:MI_docs:`BoM item types for Sustainability <rs_and_sustainability/bom_types_sustainability.html>`
-in the Granta MI product documentation.
+:MI_docs:`Item types for Sustainability <one_mi/bom_types_sustainability.html>` in the Granta
+MI product documentation.
 
 .. note:: The API documented in this section is only available if you have the MI Restricted
   Substances feature included in your license. A

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -124,7 +124,7 @@ numpydoc_validation_exclude = {
 
 extlinks = {
     'MI_docs': (
-        'https://ansyshelp.ansys.com/account/secured?returnurl=/Views/Secured/Granta/v252/en/Granta_MI/%s',
+        'https://ansyshelp.ansys.com/public/account/secured?returnurl=/Views/Secured/Granta/v252/en/Granta_MI/%s',
         None
     ),
     "OpenAPI-Common": ("https://openapi.docs.pyansys.com/version/stable/%s", None),

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -124,7 +124,7 @@ numpydoc_validation_exclude = {
 
 extlinks = {
     'MI_docs': (
-        'https://ansyshelp.ansys.com/account/secured?returnurl=/Views/Secured/Granta/v251/en/RS_and_Sustainability/%s',
+        'https://ansyshelp.ansys.com/account/secured?returnurl=/Views/Secured/Granta/v252/en/Granta_MI/%s',
         None
     ),
     "OpenAPI-Common": ("https://openapi.docs.pyansys.com/version/stable/%s", None),


### PR DESCRIPTION
Closes #851 

Update the Ansys help links to refer to the 2025 R2 equivalents. The documentation paths have changed in all cases, which required changes to the doc source code as well as the path in conf.py. I also changed the 'Indicators' link to a location which feels more appropriate for the content.