### PR TITLE
Re-work allowed_types module to support multiple arguments

### DIFF
--- a/doc/changelog.d/873.miscellaneous.md
+++ b/doc/changelog.d/873.miscellaneous.md
@@ -1,0 +1,1 @@
+Re-work allowed_types module to support multiple arguments

--- a/src/ansys/grantami/bomanalytics/_allowed_types.py
+++ b/src/ansys/grantami/bomanalytics/_allowed_types.py
@@ -31,40 +31,51 @@ T
 """
 
 import functools
+import inspect
 from typing import Any, Callable, Type, TypeVar
 
 T = TypeVar("T")
 
 
-def validate_argument_type(*allowed_types: Any) -> Callable:
-    """Validates the types of values passed into a method. This decorator function accepts one or more
-    objects against which types are checked.
+def validate_argument_type(argument_name: str, *allowed_types: Any) -> Callable:
+    """
+    Validates the types of values passed into a callable.
+
+    This decorator function accepts an argument name and one or more objects against which types are checked.
 
     * If one object is provided, the value must be of that object's type.
     * If multiple objects are provided, the value must be of at least one object's types.
     * If a container of objects is provided, the types are validated recursively.
 
-     Tuples and lists can be heterogeneous, where the ordering of the items in the containers is taken into account.
-     Dictionaries and sets must be homogeneous. If they are not exactly one item in length, a ``ValueError`` is raised.
+      - To define a homogeneous tuple or list, provide a tuple or list with a single element.
+      - To define a heterogeneous tuple or list, provide a tuple or list with the expected elements in the expected
+        positions.
+      - To define a homogeneous dictionary or set, provide a dictionary or set with a single element.
+      - Heterogeneous dictionaries or sets are not supported.
 
     Parameters
     ----------
+    argument_name : str
+        The name of the argument to be validated.
     *allowed_types
-        Tuple of objects whose type should match the corresponding function argument's type.
+        Objects whose type should match the corresponding function argument's type.
 
     Raises
     ------
     TypeError
-        If the type of an object passed to the decorator does not match the type of the corresponding argument.
-        If the number of objects passed to the decorator does not match the number of arguments passed to the wrapped
-        function.
+        On validation, if the type of an object passed to the decorator does not match the type of the corresponding
+        argument.
+        On validation, if the number of objects passed to the decorator does not match the number of arguments passed to
+        the wrapped function.
     ValueError
-        If a list or tuple does not contain either one item or a number of items equal to the container being checked.
-        If a dictionary or set does not contain exactly one item.
+        On initialization, if ``argument_name`` doesn't match an argument name in the wrapped callable.
+        On initialization, if a dictionary or set does not contain exactly one item.
+        On validation, if a list or tuple does not contain either one item or a number of items equal to the container
+        being checked.
 
     Examples
     --------
-    >>> @validate_argument_type([str]):
+    >>> @validate_argument_type("records", [str]):
     >>> def process_records(self, records):
     >>>    ...
 
@@ -75,21 +86,44 @@ def validate_argument_type(*allowed_types: Any) -> Callable:
     >>> self.process_records(['Record 1', 2])  # TypeError (2 is not a str)
     """
 
-    def decorator(method: Type[T]) -> Callable[[Any, Any], T]:
-        @functools.wraps(method)
-        def check_types(*args: Any, **kwargs: Any) -> T:
-            values = list(args)[1:] + list(kwargs.values())
-            if len(values) != 1:
-                raise TypeError(
-                    f"The allowed_types decorator can only be used on a method called with "
-                    f'exactly one argument. The method "{method.__name__}" was called with {len(values)} '
-                    f"arguments."
+    for allowed_type in allowed_types:
+        if isinstance(allowed_type, (dict, set)):
+            if len(allowed_type) != 1:
+                raise ValueError(
+                    f"{type(allowed_type)} must contain exactly 1 item. '{allowed_type}' has length {len(allowed_type)}"
                 )
-            value = values[0]
-            result = any([_check_type_wrapper(value, allowed_type) for allowed_type in allowed_types])
+
+    def decorator(callable_: Type[T]) -> Callable[[Any, Any], T]:
+        callable_params = inspect.signature(callable_).parameters
+
+        if argument_name not in callable_params:
+            raise ValueError(f"Argument '{argument_name}' not found in signature for callable {repr(callable_)}")
+
+        @functools.wraps(callable_)
+        def check_types(*args: Any, **kwargs: Any) -> T:
+            # First check if the argument was provided as a kwarg
+            try:
+                value = kwargs[argument_name]
+            except KeyError:
+                # If not, try to extract from the tuple of positional args
+                for idx, param in enumerate(callable_params.keys()):
+                    if param == argument_name:
+                        break
+                try:
+                    value = args[idx]
+                except IndexError:
+                    # If there are not enough positional parameters, then this argument wasn't provided.
+                    return callable_(*args, **kwargs)
+
+            result = any([_check_type_wrapper(value, t) for t in allowed_types])
             if not result:
-                raise TypeError(f'Incorrect type for value "{value}". Expected "{allowed_types}"')
-            return method(*args, **kwargs)
+                allowed_types_str = ", ".join(f"'{repr(t)}'" for t in allowed_types)
+                if len(allowed_types) != 1:
+                    allowed_types_str = f"one of {allowed_types_str}"
+                raise TypeError(
+                    f"Incorrect type for argument '{argument_name}' value {repr(value)}. Expected {allowed_types_str}"
+                )
+            return callable_(*args, **kwargs)
 
         return check_types
 
@@ -132,7 +166,7 @@ def _check_type(value_obj: Any, type_obj: Any) -> None:
     """
 
     if isinstance(type_obj, (list, tuple)):
-        if not isinstance(value_obj, (list, tuple)):
+        if not isinstance(value_obj, type(type_obj)):
             raise AssertionError
         if len(type_obj) == 1:
             contained_type = type_obj[0]
@@ -147,31 +181,24 @@ def _check_type(value_obj: Any, type_obj: Any) -> None:
                 "object being checked."
                 f"Container length: {len(type_obj)}, object length: {len(value_obj)}"
             )
+
     elif isinstance(type_obj, set):
         if not isinstance(value_obj, set):
             raise AssertionError
-        if len(type_obj) != 1:
-            raise ValueError(
-                "Sets must be homogeneous: they can only contain a single object against "
-                "which the type should be checked."
-            )
         contained_type = next(iter(type_obj))
         for value in value_obj:
             _check_type(value, contained_type)
+
     elif isinstance(type_obj, dict):
         if not isinstance(value_obj, dict):
             raise AssertionError
-        if len(type_obj) != 1:
-            raise ValueError(
-                "Dictionaries must be homogeneous: they can only contain a single object "
-                "against which the type should be checked."
-            )
         contained_key_type = next(iter(type_obj.keys()))
         for key in value_obj.keys():
             _check_type(key, contained_key_type)
         contained_value_type = next(iter(type_obj.values()))
         for value in value_obj.values():
             _check_type(value, contained_value_type)
+
     else:
         if not isinstance(value_obj, type_obj):
             raise AssertionError

--- a/src/ansys/grantami/bomanalytics/_allowed_types.py
+++ b/src/ansys/grantami/bomanalytics/_allowed_types.py
@@ -32,7 +32,7 @@ T
 
 import functools
 import inspect
-from typing import Any, Callable, Type, TypeVar
+from typing import Any, Callable, TypeVar
 
 T = TypeVar("T")
 
@@ -93,7 +93,7 @@ def validate_argument_type(argument_name: str, *allowed_types: Any) -> Callable:
                     f"{type(allowed_type)} must contain exactly 1 item. '{allowed_type}' has length {len(allowed_type)}"
                 )
 
-    def decorator(callable_: Type[T]) -> Callable[[Any, Any], T]:
+    def decorator(callable_: Callable[..., T]) -> Callable[..., T]:
         callable_params = inspect.signature(callable_).parameters
 
         if argument_name not in callable_params:

--- a/src/ansys/grantami/bomanalytics/queries.py
+++ b/src/ansys/grantami/bomanalytics/queries.py
@@ -366,7 +366,7 @@ class _RecordBasedQueryBuilder(_BaseQueryBuilder, ABC):
     def __repr__(self) -> str:
         return f"<{self.__class__.__name__}: {self._data}>"
 
-    @validate_argument_type(int)
+    @validate_argument_type("batch_size", int)
     def with_batch_size(self: _RecordQuery, batch_size: int) -> _RecordQuery:
         """Set the number of records to include in a single request for this query.
 
@@ -414,7 +414,7 @@ class _RecordBasedQueryBuilder(_BaseQueryBuilder, ABC):
         self._data.batch_size = batch_size
         return self
 
-    @validate_argument_type([int], {int})
+    @validate_argument_type("record_history_identities", [int], {int})
     def with_record_history_ids(self: _RecordQuery, record_history_identities: List[int]) -> _RecordQuery:
         """Add a list or set of record history identities to a query.
 
@@ -447,7 +447,7 @@ class _RecordBasedQueryBuilder(_BaseQueryBuilder, ABC):
             self._data.append_record_definition(item_reference)
         return self
 
-    @validate_argument_type([str], {str})
+    @validate_argument_type("record_history_guids", [str], {str})
     def with_record_history_guids(self: _RecordQuery, record_history_guids: List[str]) -> _RecordQuery:
         """Add a list or set of record history GUIDs to a query.
 
@@ -481,7 +481,7 @@ class _RecordBasedQueryBuilder(_BaseQueryBuilder, ABC):
             self._data.append_record_definition(item_reference)
         return self
 
-    @validate_argument_type([str], {str})
+    @validate_argument_type("record_guids", [str], {str})
     def with_record_guids(self: _RecordQuery, record_guids: List[str]) -> _RecordQuery:
         """Add a list or set of record GUIDs to a query.
 
@@ -616,7 +616,7 @@ class _ComplianceMixin(_ApiMixin, ABC):
         result = f"<{self.__class__.__name__}: {self._data}," f" {len(self._indicators)} indicators>"
         return result
 
-    @validate_argument_type([_Indicator], {_Indicator})
+    @validate_argument_type("indicators", [_Indicator], {_Indicator})
     def with_indicators(
         self: _ComplianceQuery, indicators: List[Union[WatchListIndicator, RoHSIndicator]]
     ) -> _ComplianceQuery:
@@ -741,7 +741,7 @@ class _ImpactedSubstanceMixin(_ApiMixin, ABC):
         result = f"<{self.__class__.__name__}: {self._data}, " f"{len(self._legislations)} legislations>"
         return result
 
-    @validate_argument_type([str], {str})
+    @validate_argument_type("legislation_ids", [str], {str})
     def with_legislation_ids(self: _ImpactedSubstanceQuery, legislation_ids: List[str]) -> _ImpactedSubstanceQuery:
         """Add a list or set of legislations to retrieve the impacted substances for.
 
@@ -830,7 +830,7 @@ class _MaterialQueryBuilder(_RecordBasedQueryBuilder, ABC):
         self._data.item_type_name = "materials"
         self._data.batch_size = 100
 
-    @validate_argument_type([str], {str})
+    @validate_argument_type("material_ids", [str], {str})
     def with_material_ids(self: _MaterialQuery, material_ids: List[str]) -> _MaterialQuery:
         """Add a list or set of materials to a material query, referenced by the material ID attribute value.
 
@@ -937,7 +937,7 @@ class _PartQueryBuilder(_RecordBasedQueryBuilder, ABC):
         self._data.item_type_name = "parts"
         self._data.batch_size = 10
 
-    @validate_argument_type([str], {str})
+    @validate_argument_type("part_numbers", [str], {str})
     def with_part_numbers(self: _PartQuery, part_numbers: List[str]) -> _PartQuery:
         """Add a list or set of parts to a part query, referenced by part number.
 
@@ -1043,7 +1043,7 @@ class _SpecificationQueryBuilder(_RecordBasedQueryBuilder, ABC):
         self._data.item_type_name = "specifications"
         self._data.batch_size = 10
 
-    @validate_argument_type([str], {str})
+    @validate_argument_type("specification_ids", [str], {str})
     def with_specification_ids(self: _SpecificationQuery, specification_ids: List[str]) -> _SpecificationQuery:
         """Add a list or set of specifications to a specification query, referenced by specification ID.
 
@@ -1153,7 +1153,7 @@ class _SubstanceQueryBuilder(_RecordBasedQueryBuilder, ABC):
         self._data.item_type_name = "substances"
         self._data.batch_size = 500
 
-    @validate_argument_type([str], {str})
+    @validate_argument_type("cas_numbers", [str], {str})
     def with_cas_numbers(self: _SubstanceQuery, cas_numbers: List[str]) -> _SubstanceQuery:
         """Add a list or set of CAS numbers to a substance query.
 
@@ -1185,7 +1185,7 @@ class _SubstanceQueryBuilder(_RecordBasedQueryBuilder, ABC):
             self._data.append_record_definition(item_reference)
         return self
 
-    @validate_argument_type([str], {str})
+    @validate_argument_type("ec_numbers", [str], {str})
     def with_ec_numbers(self: "_SubstanceQueryBuilder", ec_numbers: List[str]) -> "_SubstanceQueryBuilder":
         """Add a list or set of EC numbers to a substance query.
 
@@ -1217,7 +1217,7 @@ class _SubstanceQueryBuilder(_RecordBasedQueryBuilder, ABC):
             self._data.append_record_definition(item_reference)
         return self
 
-    @validate_argument_type([str], {str})
+    @validate_argument_type("chemical_names", [str], {str})
     def with_chemical_names(self: "_SubstanceQueryBuilder", chemical_names: List[str]) -> "_SubstanceQueryBuilder":
         """Add a list or set of chemical names to a substance query.
 
@@ -1249,7 +1249,7 @@ class _SubstanceQueryBuilder(_RecordBasedQueryBuilder, ABC):
             self._data.append_record_definition(item_reference)
         return self
 
-    @validate_argument_type([(int, Number)], {(int, Number)})
+    @validate_argument_type("record_history_identities_and_amounts", [(int, Number)], {(int, Number)})
     def with_record_history_ids_and_amounts(
         self: "_SubstanceQueryBuilder", record_history_identities_and_amounts: List[Tuple[int, float]]
     ) -> "_SubstanceQueryBuilder":
@@ -1287,7 +1287,7 @@ class _SubstanceQueryBuilder(_RecordBasedQueryBuilder, ABC):
             self._data.append_record_definition(item_reference)
         return self
 
-    @validate_argument_type([(str, Number)], {(str, Number)})
+    @validate_argument_type("record_history_guids_and_amounts", [(str, Number)], {(str, Number)})
     def with_record_history_guids_and_amounts(
         self: "_SubstanceQueryBuilder", record_history_guids_and_amounts: List[Tuple[str, float]]
     ) -> "_SubstanceQueryBuilder":
@@ -1328,7 +1328,7 @@ class _SubstanceQueryBuilder(_RecordBasedQueryBuilder, ABC):
             self._data.append_record_definition(item_reference)
         return self
 
-    @validate_argument_type([(str, Number)], {(str, Number)})
+    @validate_argument_type("record_guids_and_amounts", [(str, Number)], {(str, Number)})
     def with_record_guids_and_amounts(
         self: "_SubstanceQueryBuilder", record_guids_and_amounts: List[Tuple[str, float]]
     ) -> "_SubstanceQueryBuilder":
@@ -1367,7 +1367,7 @@ class _SubstanceQueryBuilder(_RecordBasedQueryBuilder, ABC):
             self._data.append_record_definition(item_reference)
         return self
 
-    @validate_argument_type([(str, Number)], {(str, Number)})
+    @validate_argument_type("cas_numbers_and_amounts", [(str, Number)], {(str, Number)})
     def with_cas_numbers_and_amounts(
         self: "_SubstanceQueryBuilder", cas_numbers_and_amounts: List[Tuple[str, float]]
     ) -> "_SubstanceQueryBuilder":
@@ -1403,7 +1403,7 @@ class _SubstanceQueryBuilder(_RecordBasedQueryBuilder, ABC):
             self._data.append_record_definition(item_reference)
         return self
 
-    @validate_argument_type([(str, Number)], {(str, Number)})
+    @validate_argument_type("ec_numbers_and_amounts", [(str, Number)], {(str, Number)})
     def with_ec_numbers_and_amounts(
         self: "_SubstanceQueryBuilder", ec_numbers_and_amounts: List[Tuple[str, float]]
     ) -> "_SubstanceQueryBuilder":
@@ -1440,7 +1440,7 @@ class _SubstanceQueryBuilder(_RecordBasedQueryBuilder, ABC):
             self._data.append_record_definition(item_reference)
         return self
 
-    @validate_argument_type([(str, Number)], {(str, Number)})
+    @validate_argument_type("chemical_names_and_amounts", [(str, Number)], {(str, Number)})
     def with_chemical_names_and_amounts(
         self: "_SubstanceQueryBuilder", chemical_names_and_amounts: List[Tuple[str, float]]
     ) -> "_SubstanceQueryBuilder":
@@ -1635,7 +1635,7 @@ class _BomQueryBuilder(_BaseQueryBuilder, ABC):
     def __init__(self) -> None:
         self._data: _BomQueryDataManager = _BomQueryDataManager(self._supported_bom_formats)
 
-    @validate_argument_type(str)
+    @validate_argument_type("bom", str)
     def with_bom(self: _BomQuery, bom: str) -> _BomQuery:
         """Set the BoM to use for the query.
 

--- a/tests/test_allowed_types.py
+++ b/tests/test_allowed_types.py
@@ -21,105 +21,382 @@
 # SOFTWARE.
 
 from numbers import Number
+from typing import Optional
 
 import pytest
 
 from ansys.grantami.bomanalytics._allowed_types import _check_type, validate_argument_type
 
-
-def test_allowed_types_args():
-    @validate_argument_type(int)
-    def test_function(*args):
-        return args
-
-    # The function is expected to be a method, so "self" fills the expected role of self as the first positional arg
-    result = test_function("self", 23)
-    assert result == ("self", 23)
-
-
-def test_allowed_types_kwargs():
-    @validate_argument_type(int)
-    def test_function(*args, **kwargs):
-        return kwargs
-
-    result = test_function("self", value=23)
-    assert result == {"value": 23}
+valid_types = [
+    (int,),
+    (int, int),
+    (int, str),
+    ([int],),
+    ([int, int],),
+    ([int, str],),
+    ((int,),),
+    ((int, int),),
+    ((int, str),),
+    ({int: int},),
+    ({int},),
+]
 
 
-def test_different_lengths_type_error():
-    @validate_argument_type(int)
-    def test_function(*args):
-        return args
+class TestInitialization:
+    @pytest.mark.parametrize("allowed_types", valid_types)
+    def test_single_arg(self, allowed_types):
+        @validate_argument_type("arg_1", *allowed_types)
+        def func(arg_1):
+            pass
 
-    with pytest.raises(TypeError) as e:
-        test_function("self", 23, 34)
-    assert 'The method "test_function" was called with 2 arguments.' in str(e.value)
+    @pytest.mark.parametrize("allowed_types_arg_1", valid_types)
+    @pytest.mark.parametrize("allowed_types_arg_2", valid_types)
+    def test_two_args_both_checked(self, allowed_types_arg_1, allowed_types_arg_2):
+        @validate_argument_type("arg_1", *allowed_types_arg_1)
+        @validate_argument_type("arg_2", *allowed_types_arg_2)
+        def func(arg_1, arg_2):
+            pass
+
+    @pytest.mark.parametrize("allowed_types", valid_types)
+    def test_two_args_first_checked(self, allowed_types):
+        @validate_argument_type("arg_1", *allowed_types)
+        def func(arg_1, arg_2):
+            pass
+
+    @pytest.mark.parametrize("allowed_types", valid_types)
+    def test_two_args_second_checked(self, allowed_types):
+        @validate_argument_type("arg_2", *allowed_types)
+        def func(arg_1, arg_2):
+            pass
+
+    def test_one_arg_invalid_arg_name_raises(self):
+        with pytest.raises(ValueError, match="Argument 'invalid_arg' not found in signature for callable.+func"):
+
+            @validate_argument_type("invalid_arg", int)
+            def func(arg_1):
+                pass
+
+    def test_two_args_invalid_arg_name_raises(self):
+        with pytest.raises(ValueError, match="Argument 'invalid_arg' not found in signature for callable.+func"):
+
+            @validate_argument_type("invalid_arg", int)
+            @validate_argument_type("arg_1", int)
+            @validate_argument_type("arg_2", int)
+            def func(arg_1, arg_2):
+                pass
+
+    @pytest.mark.parametrize(
+        ["allowed_types", "msg"],
+        [
+            (
+                ({int, str},),
+                r"<class 'set'> must contain exactly 1 item\. '{<class 'int'>, <class 'str'>}' has length 2",
+            ),
+            (
+                ({int: str, str: str},),
+                (
+                    r"<class 'dict'> must contain exactly 1 item\. '{<class 'int'>: <class 'str'>, <class 'str'>: "
+                    r"<class 'str'>}' has length 2"
+                ),
+            ),
+        ],
+    )
+    def test_invalid_types_raise(self, allowed_types, msg):
+        with pytest.raises(ValueError, match=msg):
+
+            @validate_argument_type("arg_1", *allowed_types)
+            def func(arg_1):
+                pass
 
 
-def test_different_types_type_error():
-    @validate_argument_type(int)
-    def test_function(*args):
-        return args
+class TestSingleArgSingleSimpleType:
+    @staticmethod
+    @validate_argument_type("arg_1", int)
+    def func(arg_1: Optional[int] = 5):
+        return arg_1
 
-    with pytest.raises(TypeError) as e:
-        test_function("self", "test")
-    assert f'Incorrect type for value "test". Expected "(<class \'int\'>,)"' in str(e.value)
+    def test_valid_value_positional(self):
+        assert self.func(5) == 5
+
+    def test_valid_value_keyword(self):
+        assert self.func(arg_1=5) == 5
+
+    def test_valid_value_not_provided(self):
+        assert self.func() == 5
+
+    def test_invalid_simple_type_positional(self):
+        with pytest.raises(
+            TypeError,
+            match=r"Incorrect type for argument 'arg_1' value '5'. Expected '<class 'int'>'",
+        ):
+            self.func("5")
+
+    def test_invalid_simple_type_keyword(self):
+        with pytest.raises(
+            TypeError,
+            match="Incorrect type for argument 'arg_1' value '5'. Expected '<class 'int'>'",
+        ):
+            self.func(arg_1="5")
+
+    def test_invalid_container_positional(self):
+        with pytest.raises(
+            TypeError,
+            match=r"Incorrect type for argument 'arg_1' value \[5\]. Expected '<class 'int'>'",
+        ):
+            self.func([5])
+
+    def test_invalid_container_keyword(self):
+        with pytest.raises(
+            TypeError,
+            match=r"Incorrect type for argument 'arg_1' value \[5\]. Expected '<class 'int'>'",
+        ):
+            self.func(arg_1=[5])
 
 
-@pytest.mark.parametrize(
-    "obj, allowed_type",
-    [
-        ("test", str),
-        (123, int),
-        (123, Number),
-        ([1, 2], [int]),
-        ([1, "2"], [int, str]),
-        ((1, 2), (int,)),
-        ((1, 2), (int, int)),
-        ({1, 2}, {int}),
-        ({1, 2}, {int, int}),
-        ({"a": 5.5, "b": 10.0}, {str: float}),
-        ({"a": [1, 2], "b": [3, 4]}, {str: [int]}),
-        ({"a": [1, 2], "b": [3, 4]}, object),
-        ({"a": [1, 2], "b": [3, 4]}, {str: [object]}),
-    ],
-)
-def test_check_type_success(obj, allowed_type):
-    _check_type(obj, allowed_type)
+class TestSingleArgMultipleSimpleType:
+    @staticmethod
+    @validate_argument_type("arg_1", int, str)
+    def func(arg_1: Optional[int | str] = 5):
+        return arg_1
+
+    @pytest.mark.parametrize("value", [5, "five"])
+    def test_valid_value_positional(self, value):
+        assert self.func(value) == value
+
+    @pytest.mark.parametrize("value", [5, "five"])
+    def test_valid_value_keyword(self, value):
+        assert self.func(arg_1=value) == value
+
+    def test_valid_value_not_provided(self):
+        assert self.func() == 5
+
+    def test_invalid_simple_type_positional(self):
+        with pytest.raises(
+            TypeError,
+            match=(
+                r"Incorrect type for argument 'arg_1' value 28\.123. Expected one of '<class 'int'>', '<class 'str'>'"
+            ),
+        ):
+            self.func(28.123)
+
+    def test_invalid_simple_type_keyword(self):
+        with pytest.raises(
+            TypeError,
+            match=(
+                r"Incorrect type for argument 'arg_1' value 28\.123. Expected one of '<class 'int'>', '<class 'str'>'"
+            ),
+        ):
+            self.func(arg_1=28.123)
+
+    def test_invalid_container_positional(self):
+        with pytest.raises(
+            TypeError,
+            match=(
+                r"Incorrect type for argument 'arg_1' value \[5\]. Expected one of '<class 'int'>', '<class 'str'>'"
+            ),
+        ):
+            self.func([5])
+
+    def test_invalid_container_keyword(self):
+        with pytest.raises(
+            TypeError,
+            match=(
+                r"Incorrect type for argument 'arg_1' value \[5\]. Expected one of '<class 'int'>', '<class 'str'>'"
+            ),
+        ):
+            self.func(arg_1=[5])
 
 
-@pytest.mark.parametrize(
-    "obj, allowed_type",
-    [
-        ("test", int),
-        (123, str),
-        ([1, 2], [float]),
-        ([1, 2], [int, str]),
-        ([1, 2], {str: int}),
-        (["1", 2], [int, str]),
-        ((5, 10), (str,)),
-        ({1, 2}, {str}),
-        ({"a": 5.5, "b": 10.0}, []),
-        ({"a": 5.5, "b": 10.0}, {float}),
-        ({"a": 5.5, "b": 10.0}, {str: int}),
-        ({"a": [1, 2], "b": [3, 4]}, {str: [str]}),
-    ],
-)
-def test_check_type_wrong_type(obj, allowed_type):
-    with pytest.raises(AssertionError):
+class TestSingleArgSingleContainerType:
+    @staticmethod
+    @validate_argument_type("arg_1", [str])
+    def func(arg_1: Optional[list[str]] = None):
+        if arg_1 is None:
+            arg_1 = ["test"]
+        return arg_1
+
+    def test_valid_value_positional(self):
+        assert self.func(["blue"]) == ["blue"]
+
+    def test_valid_value_keyword(self):
+        assert self.func(arg_1=["blue"]) == ["blue"]
+
+    def test_valid_value_not_provided(self):
+        assert self.func() == ["test"]
+
+    def test_invalid_simple_type_positional(self):
+        with pytest.raises(
+            TypeError,
+            match=r"Incorrect type for argument 'arg_1' value 'blue'. Expected '\[<class 'str'>\]'",
+        ):
+            self.func("blue")
+
+    def test_invalid_simple_type_keyword(self):
+        with pytest.raises(
+            TypeError,
+            match=r"Incorrect type for argument 'arg_1' value 'blue'. Expected '\[<class 'str'>\]'",
+        ):
+            self.func(arg_1="blue")
+
+    def test_invalid_container_positional(self):
+        with pytest.raises(
+            TypeError,
+            match=r"Incorrect type for argument 'arg_1' value \{'blue'\}. Expected '\[<class 'str'>\]'",
+        ):
+            self.func({"blue"})
+
+    def test_invalid_container_keyword(self):
+        with pytest.raises(
+            TypeError,
+            match=r"Incorrect type for argument 'arg_1' value \{'blue'\}. Expected '\[<class 'str'>\]'",
+        ):
+            self.func(arg_1={"blue"})
+
+
+class TestTwoArgsSingleSimpleTypes:
+    @staticmethod
+    @validate_argument_type("arg_1", int)
+    @validate_argument_type("arg_2", str)
+    def func(arg_1, arg_2: Optional[str] = "test"):
+        return arg_1, arg_2
+
+    def test_valid_value_positional(self):
+        assert self.func(5, "red") == (5, "red")
+
+    def test_valid_value_keyword(self):
+        assert self.func(arg_1=5, arg_2="red") == (5, "red")
+
+    def test_valid_value_mixed_args(self):
+        assert self.func(5, arg_2="red") == (5, "red")
+
+    def test_valid_value_not_provided(self):
+        assert self.func(5) == (5, "test")
+
+    def test_invalid_simple_type_first_arg(self):
+        with pytest.raises(
+            TypeError,
+            match=r"Incorrect type for argument 'arg_1' value '5'. Expected '<class 'int'>'",
+        ):
+            self.func(arg_1="5", arg_2="red")
+
+    def test_invalid_simple_type_second_arg(self):
+        with pytest.raises(
+            TypeError,
+            match=r"Incorrect type for argument 'arg_2' value 25.1. Expected '<class 'str'>'",
+        ):
+            self.func(arg_1=5, arg_2=25.1)
+
+    def test_invalid_container_first_arg(self):
+        with pytest.raises(
+            TypeError,
+            match=r"Incorrect type for argument 'arg_1' value \[5\]. Expected '<class 'int'>'",
+        ):
+            self.func(arg_1=[5], arg_2="red")
+
+    def test_invalid_container_second_arg(self):
+        with pytest.raises(
+            TypeError,
+            match=r"Incorrect type for argument 'arg_2' value \['red'\]. Expected '<class 'str'>'",
+        ):
+            self.func(arg_1=5, arg_2=["red"])
+
+
+class TestTwoArgsSingleSimpleAndContainerTypes:
+    @staticmethod
+    @validate_argument_type("arg_1", (int,))
+    @validate_argument_type("arg_2", str)
+    def func(arg_1, arg_2):
+        return arg_1, arg_2
+
+    def test_valid_value_positional(self):
+        assert self.func((5, 7), "red") == ((5, 7), "red")
+
+    def test_valid_value_keyword(self):
+        assert self.func(arg_1=(5, 7), arg_2="red") == ((5, 7), "red")
+
+    def test_valid_value_mixed_args(self):
+        assert self.func((5, 7), arg_2="red") == ((5, 7), "red")
+
+    def test_invalid_container_type_first_arg(self):
+        with pytest.raises(
+            TypeError,
+            match=r"Incorrect type for argument 'arg_1' value '5'. Expected '\(<class 'int'>,\)'",
+        ):
+            self.func(arg_1="5", arg_2="red")
+
+    def test_invalid_simple_type_second_arg(self):
+        with pytest.raises(
+            TypeError,
+            match="Incorrect type for argument 'arg_2' value 25.1. Expected '<class 'str'>'",
+        ):
+            self.func(arg_1=(5,), arg_2=25.1)
+
+    def test_invalid_container_first_arg(self):
+        with pytest.raises(
+            TypeError,
+            match=r"Incorrect type for argument 'arg_1' value \[5\]. Expected '\(<class 'int'>,\)'",
+        ):
+            self.func(arg_1=[5], arg_2="red")
+
+    def test_invalid_container_second_arg(self):
+        with pytest.raises(
+            TypeError,
+            match=r"Incorrect type for argument 'arg_2' value \['red'\]. Expected '<class 'str'>'",
+        ):
+            self.func(arg_1=(5,), arg_2=["red"])
+
+
+class TestCheckType:
+    @pytest.mark.parametrize(
+        "obj, allowed_type",
+        [
+            ("test", str),
+            (123, int),
+            (123, Number),
+            ([1, 2], [int]),
+            ([1, "2"], [int, str]),
+            ((1, 2), (int,)),
+            ((1, 2), (int, int)),
+            ({1, 2}, {int}),
+            ({1, 2}, {int, int}),
+            ({"a": 5.5, "b": 10.0}, {str: float}),
+            ({"a": [1, 2], "b": [3, 4]}, {str: [int]}),
+            ({"a": [1, 2], "b": [3, 4]}, object),
+            ({"a": [1, 2], "b": [3, 4]}, {str: [object]}),
+        ],
+    )
+    def test_check_type_success(self, obj, allowed_type):
         _check_type(obj, allowed_type)
 
+    @pytest.mark.parametrize(
+        "obj, allowed_type",
+        [
+            ("test", int),
+            (123, str),
+            ([1, 2], [float]),
+            ([1, 2], [int, str]),
+            ([1, 2], {str: int}),
+            (["1", 2], [int, str]),
+            ((5, 10), (str,)),
+            ({1, 2}, {str}),
+            ({"a": 5.5, "b": 10.0}, []),
+            ({"a": 5.5, "b": 10.0}, {float}),
+            ({"a": 5.5, "b": 10.0}, {str: int}),
+            ({"a": [1, 2], "b": [3, 4]}, {str: [str]}),
+        ],
+    )
+    def test_check_type_wrong_type(self, obj, allowed_type):
+        with pytest.raises(AssertionError):
+            _check_type(obj, allowed_type)
 
-@pytest.mark.parametrize(
-    "obj, allowed_type",
-    [
-        (("test",), (str, str)),
-        (("test", "test2"), (str, str, str)),
-        (("test", "test2", "test3"), (str, str)),
-        ({"a": 5.5, "b": 10.0}, {}),
-        ({1, 2.5}, {int, float}),
-    ],
-)
-def test_check_type_wrong_container_length(obj, allowed_type):
-    with pytest.raises(ValueError):
-        _check_type(obj, allowed_type)
+    @pytest.mark.parametrize(
+        "obj, allowed_type",
+        [
+            (("test",), (str, str)),
+            (("test", "test2"), (str, str, str)),
+            (("test", "test2", "test3"), (str, str)),
+        ],
+    )
+    def test_check_type_wrong_container_length(self, obj, allowed_type):
+        with pytest.raises(ValueError):
+            _check_type(obj, allowed_type)

--- a/tests/test_allowed_types.py
+++ b/tests/test_allowed_types.py
@@ -88,14 +88,8 @@ class TestInitialization:
     @pytest.mark.parametrize(
         ["allowed_types", "msg"],
         [
-            (
-                ({int, str},),
-                r"<class 'set'> must contain exactly 1 item.+has length 2",
-            ),
-            (
-                ({int: str, str: str},),
-                (r"<class 'dict'> must contain exactly 1 item.+has length 2"),
-            ),
+            (({int, str},), r"<class 'set'> must contain exactly 1 item.+has length 2"),
+            (({int: str, str: str},), r"<class 'dict'> must contain exactly 1 item.+has length 2"),
         ],
     )
     def test_invalid_types_raise(self, allowed_types, msg):

--- a/tests/test_allowed_types.py
+++ b/tests/test_allowed_types.py
@@ -90,14 +90,11 @@ class TestInitialization:
         [
             (
                 ({int, str},),
-                r"<class 'set'> must contain exactly 1 item\. '{<class 'int'>, <class 'str'>}' has length 2",
+                r"<class 'set'> must contain exactly 1 item.+has length 2",
             ),
             (
                 ({int: str, str: str},),
-                (
-                    r"<class 'dict'> must contain exactly 1 item\. '{<class 'int'>: <class 'str'>, <class 'str'>: "
-                    r"<class 'str'>}' has length 2"
-                ),
+                (r"<class 'dict'> must contain exactly 1 item.+has length 2"),
             ),
         ],
     )

--- a/tests/test_query_builders/test_bom.py
+++ b/tests/test_query_builders/test_bom.py
@@ -49,10 +49,10 @@ def test_add_bom(query_type):
 def test_add_bom_wrong_type(query_type):
     with pytest.raises(TypeError) as e:
         query_type().with_bom(12345)
-    assert "Incorrect type for value" in str(e.value)
+    assert "Incorrect type for argument 'bom'" in str(e.value)
     with pytest.raises(TypeError) as e:
         query_type().with_bom(bom=12345)
-    assert "Incorrect type for value" in str(e.value)
+    assert "Incorrect type for argument 'bom'" in str(e.value)
 
 
 @all_bom_queries

--- a/tests/test_query_builders/test_materials.py
+++ b/tests/test_query_builders/test_materials.py
@@ -44,7 +44,7 @@ def test_add_material_ids(query_type, material_ids):
 def test_add_material_ids_wrong_type(query_type):
     with pytest.raises(TypeError) as e:
         query_type().with_material_ids("Strings are not allowed")
-    assert 'Incorrect type for value "Strings are not allowed"' in str(e.value)
+    assert "Incorrect type for argument 'material_ids' value 'Strings are not allowed'" in str(e.value)
     with pytest.raises(TypeError) as e:
         query_type().with_material_ids(material_ids="Strings are not allowed")
-    assert 'Incorrect type for value "Strings are not allowed"' in str(e.value)
+    assert "Incorrect type for argument 'material_ids' value 'Strings are not allowed'" in str(e.value)

--- a/tests/test_query_builders/test_parts.py
+++ b/tests/test_query_builders/test_parts.py
@@ -44,7 +44,7 @@ def test_add_part_numbers(query_type, part_numbers):
 def test_add_part_numbers_wrong_type(query_type):
     with pytest.raises(TypeError) as e:
         query_type().with_part_numbers("Strings are not allowed")
-    assert 'Incorrect type for value "Strings are not allowed"' in str(e.value)
+    assert "Incorrect type for argument 'part_numbers' value 'Strings are not allowed'" in str(e.value)
     with pytest.raises(TypeError) as e:
         query_type().with_part_numbers(part_numbers="Strings are not allowed")
-    assert 'Incorrect type for value "Strings are not allowed"' in str(e.value)
+    assert "Incorrect type for argument 'part_numbers' value 'Strings are not allowed'" in str(e.value)

--- a/tests/test_query_builders/test_specifications.py
+++ b/tests/test_query_builders/test_specifications.py
@@ -48,7 +48,7 @@ def test_add_spec_ids(query_type, spec_ids):
 def test_add_spec_ids_wrong_type(query_type):
     with pytest.raises(TypeError) as e:
         query_type().with_specification_ids("Strings are not allowed")
-    assert 'Incorrect type for value "Strings are not allowed"' in str(e.value)
+    assert "Incorrect type for argument 'specification_ids' value 'Strings are not allowed'" in str(e.value)
     with pytest.raises(TypeError) as e:
         query_type().with_specification_ids(specification_ids="Strings are not allowed")
-    assert 'Incorrect type for value "Strings are not allowed"' in str(e.value)
+    assert "Incorrect type for argument 'specification_ids' value 'Strings are not allowed'" in str(e.value)

--- a/tests/test_query_builders/test_substances.py
+++ b/tests/test_query_builders/test_substances.py
@@ -91,26 +91,26 @@ class TestWithoutAmountsWrongType:
     def test_add_chemical_names(self, values):
         with pytest.raises(TypeError) as e:
             SubstanceCompliance().with_chemical_names(values)
-        assert "Incorrect type for value" in str(e.value)
+        assert "Incorrect type for argument 'chemical_names' value" in str(e.value)
         with pytest.raises(TypeError) as e:
             SubstanceCompliance().with_chemical_names(chemical_names=values)
-        assert "Incorrect type for value" in str(e.value)
+        assert "Incorrect type for argument 'chemical_names' value" in str(e.value)
 
     def test_add_cas_numbers(self, values):
         with pytest.raises(TypeError) as e:
             SubstanceCompliance().with_cas_numbers(values)
-        assert "Incorrect type for value" in str(e.value)
+        assert "Incorrect type for argument 'cas_numbers' value" in str(e.value)
         with pytest.raises(TypeError) as e:
             SubstanceCompliance().with_cas_numbers(cas_numbers=values)
-        assert "Incorrect type for value" in str(e.value)
+        assert "Incorrect type for argument 'cas_numbers' value" in str(e.value)
 
     def test_add_ec_numbers(self, values):
         with pytest.raises(TypeError) as e:
             SubstanceCompliance().with_ec_numbers(values)
-        assert "Incorrect type for value" in str(e.value)
+        assert "Incorrect type for argument 'ec_numbers' value" in str(e.value)
         with pytest.raises(TypeError) as e:
             SubstanceCompliance().with_ec_numbers(ec_numbers=values)
-        assert "Incorrect type for value" in str(e.value)
+        assert "Incorrect type for argument 'ec_numbers' value" in str(e.value)
 
 
 @pytest.mark.parametrize(
@@ -243,47 +243,47 @@ class TestWithAmountsWrongType:
     def test_record_guids(self, values):
         with pytest.raises(TypeError) as e:
             SubstanceCompliance().with_record_guids_and_amounts(values)
-        assert f"Incorrect type for value" in str(e.value)
+        assert "Incorrect type for argument 'record_guids_and_amounts' value" in str(e.value)
         with pytest.raises(TypeError) as e:
             SubstanceCompliance().with_record_guids_and_amounts(record_guids_and_amounts=values)
-        assert f"Incorrect type for value" in str(e.value)
+        assert "Incorrect type for argument 'record_guids_and_amounts' value" in str(e.value)
 
     def test_record_history_guids(self, values):
         with pytest.raises(TypeError) as e:
             SubstanceCompliance().with_record_history_guids_and_amounts(values)
-        assert f"Incorrect type for value" in str(e.value)
+        assert "Incorrect type for argument 'record_history_guids_and_amounts' value" in str(e.value)
         with pytest.raises(TypeError) as e:
             SubstanceCompliance().with_record_history_guids_and_amounts(record_history_guids_and_amounts=values)
-        assert f"Incorrect type for value" in str(e.value)
+        assert "Incorrect type for argument 'record_history_guids_and_amounts' value" in str(e.value)
 
     def test_record_history_ids(self, values):
         with pytest.raises(TypeError) as e:
             SubstanceCompliance().with_record_history_ids_and_amounts(values)
-        assert f"Incorrect type for value" in str(e.value)
+        assert "Incorrect type for argument 'record_history_identities_and_amounts' value" in str(e.value)
         with pytest.raises(TypeError) as e:
             SubstanceCompliance().with_record_history_ids_and_amounts(record_history_identities_and_amounts=values)
-        assert f"Incorrect type for value" in str(e.value)
+        assert "Incorrect type for argument 'record_history_identities_and_amounts' value" in str(e.value)
 
     def test_add_chemical_names(self, values):
         with pytest.raises(TypeError) as e:
             SubstanceCompliance().with_chemical_names_and_amounts(values)
-        assert f"Incorrect type for value" in str(e.value)
+        assert "Incorrect type for argument 'chemical_names_and_amounts' value" in str(e.value)
         with pytest.raises(TypeError) as e:
             SubstanceCompliance().with_chemical_names_and_amounts(chemical_names_and_amounts=values)
-        assert f"Incorrect type for value" in str(e.value)
+        assert "Incorrect type for argument 'chemical_names_and_amounts' value" in str(e.value)
 
     def test_add_cas_numbers(self, values):
         with pytest.raises(TypeError) as e:
             SubstanceCompliance().with_cas_numbers_and_amounts(values)
-        assert f"Incorrect type for value" in str(e.value)
+        assert "Incorrect type for argument 'cas_numbers_and_amounts' value" in str(e.value)
         with pytest.raises(TypeError) as e:
             SubstanceCompliance().with_cas_numbers_and_amounts(cas_numbers_and_amounts=values)
-        assert f"Incorrect type for value" in str(e.value)
+        assert "Incorrect type for argument 'cas_numbers_and_amounts' value" in str(e.value)
 
     def test_add_ec_numbers(self, values):
         with pytest.raises(TypeError) as e:
             SubstanceCompliance().with_ec_numbers_and_amounts(values)
-        assert f"Incorrect type for value" in str(e.value)
+        assert "Incorrect type for argument 'ec_numbers_and_amounts' value" in str(e.value)
         with pytest.raises(TypeError) as e:
             SubstanceCompliance().with_ec_numbers_and_amounts(ec_numbers_and_amounts=values)
-        assert f"Incorrect type for value" in str(e.value)
+        assert "Incorrect type for argument 'ec_numbers_and_amounts' value" in str(e.value)


### PR DESCRIPTION
This PR re-works the `validate_argument_type` decorator to accept an initial required argument of `argument_name`, which defines which argument will be validated by the decorator instance.

This is required by a separate in-progress PR which will introduce additional arguments to type-checked methods. In these cases, the decorator will be called multiple times for each argument that is to be type checked.

As part of this work, some checks which do not depend on the actual values are now performed when the decorator is initialized. Specifically, checking that unordered collections contain a single item are now done up-front, and raise ValueErrors in these cases.

I did look at using typeguard, but this suffers from the same problem that it did when bomanalytics was first written, in that `str` is a valid type for an `Iterable[str]` type hint. As a result, I have stuck with the custom implementation.