### PR TITLE
Convert warnings to errors during tests

### DIFF
--- a/doc/changelog.d/891.miscellaneous.md
+++ b/doc/changelog.d/891.miscellaneous.md
@@ -1,0 +1,1 @@
+Convert warnings to errors during tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,6 +125,9 @@ markers = [
     this package, the same version of the reports package and Granta MI are always used together.
     Deselect all integration tests with 'pytest -m \"not integration\"'""",
 ]
+filterwarnings = [
+	"error",
+]
 
 [tool.black]
 line-length = 120

--- a/src/ansys/grantami/bomanalytics/_bom_helper.py
+++ b/src/ansys/grantami/bomanalytics/_bom_helper.py
@@ -238,7 +238,7 @@ class BoMHandler:
         bom_dict = writer.convert_bom_to_dict(bom)
         obj, errors = schema.encode(bom_dict, validation="lax", namespaces=schema.namespaces, unordered=True)
 
-        if not obj or len(errors) > 0:
+        if obj is None or len(errors) > 0:
             newline = "\n"
             raise ValueError(f"Invalid BoM object:\n{newline.join([error.msg for error in errors])}")
 


### PR DESCRIPTION
Closes #890 

Convert warnings to errors in tests. Fix a deprecation which, as a result of these changes, now fails the tests.