### PR TITLE
Add missing dev dependencies to appropriate dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,6 +35,8 @@ updates:
         - "pre-commit"
         - "*xml"
         - "pyyaml"
+        - "kaleido"
+        - "choreographer"
       examples-deps:
         patterns:
         - "jupyterlab"


### PR DESCRIPTION
Add kaleido and choreographer to the appropriate dependabot group.

These dependencies were originally added as part of https://github.com/ansys/grantami-bomanalytics/pull/865.