### PR TITLE
Convert class-scoped fixtures to class methods

### DIFF
--- a/doc/changelog.d/1062.fixed.md
+++ b/doc/changelog.d/1062.fixed.md
@@ -1,0 +1,1 @@
+Convert class-scoped fixtures to class methods

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,6 @@ name = "private-pypi"
 url = "https://pkgs.dev.azure.com/pyansys/_packaging/pyansys/pypi/simple/"
 explicit = true
 
-
 [dependency-groups]
 dev = [
     "pytest>=9.0.0",
@@ -157,13 +156,13 @@ title_format = "`{version} <https://github.com/ansys/grantami-bomanalytics/relea
 issue_format = "`#{issue} <https://github.com/ansys/grantami-bomanalytics/pull/{issue}>`_"
 
 [[tool.towncrier.type]]
-directory = "added"
-name = "Added"
+directory = "breaking"
+name = "Breaking"
 showcontent = true
 
 [[tool.towncrier.type]]
-directory = "changed"
-name = "Changed"
+directory = "added"
+name = "Added"
 showcontent = true
 
 [[tool.towncrier.type]]
@@ -172,18 +171,13 @@ name = "Fixed"
 showcontent = true
 
 [[tool.towncrier.type]]
-directory = "dependencies"
-name = "Dependencies"
-showcontent = true
-
-[[tool.towncrier.type]]
-directory = "miscellaneous"
-name = "Miscellaneous"
-showcontent = true
-
-[[tool.towncrier.type]]
 directory = "documentation"
 name = "Documentation"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "dependencies"
+name = "Dependencies"
 showcontent = true
 
 [[tool.towncrier.type]]
@@ -192,6 +186,17 @@ name = "Maintenance"
 showcontent = true
 
 [[tool.towncrier.type]]
+directory = "miscellaneous"
+name = "Miscellaneous"
+showcontent = true
+
+[[tool.towncrier.type]]
 directory = "test"
 name = "Test"
 showcontent = true
+
+[[tool.towncrier.type]]
+directory = "changed"
+name = "Changed"
+showcontent = true
+

--- a/tests/test_bom_handler.py
+++ b/tests/test_bom_handler.py
@@ -241,7 +241,8 @@ class TestBoMDeserialization:
     # the namespace is sufficient to obtain a valid 23/01, 24/12, or 25/05 BoM.
 
     @pytest.fixture(scope="class")
-    def simple_2301_bom(self) -> eco2301.BillOfMaterials:
+    @classmethod
+    def simple_2301_bom(cls) -> eco2301.BillOfMaterials:
         bom_1711 = example_boms["bom-1711"].content
         input_bom = bom_1711.replace(
             "http://www.grantadesign.com/17/11/BillOfMaterialsEco",
@@ -251,7 +252,8 @@ class TestBoMDeserialization:
         return bom_handler.load_bom_from_text(input_bom)
 
     @pytest.fixture(scope="class")
-    def simple_2412_bom(self) -> eco2412.BillOfMaterials:
+    @classmethod
+    def simple_2412_bom(cls) -> eco2412.BillOfMaterials:
         bom_1711 = example_boms["bom-1711"].content
         input_bom = bom_1711.replace(
             "http://www.grantadesign.com/17/11/BillOfMaterialsEco",
@@ -261,7 +263,8 @@ class TestBoMDeserialization:
         return bom_handler.load_bom_from_text(input_bom)
 
     @pytest.fixture(scope="class")
-    def simple_2505_bom(self) -> eco2505.BillOfMaterials:
+    @classmethod
+    def simple_2505_bom(cls) -> eco2505.BillOfMaterials:
         bom_1711 = example_boms["bom-1711"].content
         input_bom = bom_1711.replace(
             "http://www.grantadesign.com/17/11/BillOfMaterialsEco",


### PR DESCRIPTION
Pytest 9.1 has deprecated the use of class-scoped fixtures defined as instance methods without `@classmethod`.

This repo hasn't been updated to use pytest 9.1 yet, but it will get updated soon. This change should mean that CI continues to pass once the update is applied.